### PR TITLE
Add security tests workflow

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -156,7 +156,7 @@ jobs:
         run: npm install
 
       - name: Run cypress
-        run: npm run cy:run -- --env apiKey="${{ secrets.TRAMS_API_KEY }}",url="${{ secrets.TRAMS_API_BASE_URL }}",authKey="${{ secrets.ZAP_API_KEY }}"
+        run: npm run cy:run -- --env apiKey="${{ secrets.TRAMS_API_KEY }}",url="${{ secrets.TRAMS_API_BASE_URL }}"
 
       - name: Upload screenshots
         if: ${{ failure() }}

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -1,0 +1,41 @@
+name: Security scanner tests
+
+on:
+  workflow_run:
+    workflows: ["Deploy to environment"]
+    types:
+      - completed
+
+jobs:
+  run-tests-with-zap:
+    name: Run Cypress tests with OWASP ZAP
+    environment: development
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run tests with scanner
+        env:
+          API_KEY: ${{ secrets.TRAMS_API_KEY }}
+          HTTP_PROXY: http://zap:8080
+          NO_PROXY: "*.google-analytics.com,*.googletagmanager.com,*.microsoftonline.com"
+          URL: ${{ secrets.TRAMS_API_BASE_URL }}
+          ZAP_API_KEY: ${{ secrets.ZAP_API_KEY }}
+        run: |
+          docker-compose -f CypressTests/docker-compose.yml up --exit-code-from cypress
+
+      - name: Get git sha
+        if: '!cancelled()'
+        run: |
+          CHECKED_OUT_SHA="$(git log -1 '--format=format:%H')"
+          echo "checked_out_sha=${CHECKED_OUT_SHA}" >> $GITHUB_ENV
+
+      - name: Push report to blob storage
+        if: '!cancelled()'
+        uses: azure/CLI@v1
+        id: azure
+        with:
+          azcliversion: 2.49.0
+          inlineScript: |
+            az storage azcopy blob upload -c ${{ secrets.OWASP_STORAGE_CONTAINER_NAME }} --account-name ${{ secrets.OWASP_STORAGE_ACCOUNT_NAME }} -s "CypressTests/reports/ZAP-Report.html" -d "TramsDataApi/${{ env.checked_out_sha }}/ZAP-Report.html" --sas-token "${{ secrets.OWASP_BLOB_SAS_TOKEN }}"

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -31,6 +31,12 @@ jobs:
           CHECKED_OUT_SHA="$(git log -1 '--format=format:%H')"
           echo "checked_out_sha=${CHECKED_OUT_SHA}" >> $GITHUB_ENV
 
+      - name: Azure login with SPN
+        if: '!cancelled()'
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.OWASP_AZ_CREDENTIALS }}
+
       - name: Push report to blob storage
         if: '!cancelled()'
         uses: azure/CLI@v1
@@ -38,4 +44,10 @@ jobs:
         with:
           azcliversion: 2.49.0
           inlineScript: |
-            az storage azcopy blob upload -c ${{ secrets.OWASP_STORAGE_CONTAINER_NAME }} --account-name ${{ secrets.OWASP_STORAGE_ACCOUNT_NAME }} -s "CypressTests/reports/ZAP-Report.html" -d "TramsDataApi/${{ env.checked_out_sha }}/ZAP-Report.html" --sas-token "${{ secrets.OWASP_BLOB_SAS_TOKEN }}"
+            az storage blob upload \
+              --container-name ${{ secrets.OWASP_STORAGE_CONTAINER_NAME }} \
+              --account-name ${{ secrets.OWASP_STORAGE_ACCOUNT_NAME }} \
+              --file "CypressTests/reports/ZAP-Report.html" \
+              --name "TramsDataApi/${{ env.checked_out_sha }}/ZAP-Report.html" \
+              --auth-mode login \
+              --overwrite

--- a/CypressTests/docker-compose.yml
+++ b/CypressTests/docker-compose.yml
@@ -2,10 +2,8 @@ version: "3.8"
 services:
   zap:
     container_name: zap
-    image: owasp/zap2docker-stable:2.11.1 # pinned until alpn config issue is resolved - https://github.com/zaproxy/zaproxy/issues/7699
-    command: "zap.sh -daemon -port 8080 -host 0.0.0.0 -config api.key=${ZAP_API_KEY} -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true"
-    ports:
-      - 8080:8080
+    image: owasp/zap2docker-stable
+    command: "zap.sh -daemon -port 8080 -host 0.0.0.0 -config api.key=${ZAP_API_KEY} -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true -config network.localServers.mainProxy.alpn.enabled=false -config network.localServers.mainProxy.address=0.0.0.0"
     user: zap
   cypress:
     build:
@@ -15,5 +13,8 @@ services:
     depends_on:
       zap:
         condition: service_healthy
+    environment:
+      - HTTP_PROXY=${HTTP_PROXY}
+      - NO_PROXY="${NO_PROXY}"
     volumes:
-      - ./:/reports
+      - .reports/:/reports


### PR DESCRIPTION
Adds capability to run the Cypress tests through ZAP for passive security scanning, including GitHub action to run post-deployment to dev environment.

Files will be uploaded to a [container](https://portal.azure.com/#@platform.education.gov.uk/resource/subscriptions/1d692707-6019-4f8c-b337-ec8cad61f998/resourceGroups/s184d01-rsd-owasp-reports/providers/Microsoft.Storage/storageAccounts/s184d01rsdowaspreports/storagebrowser) on Azure under the directory `<project>/<git-hash>/ZAP-Report.html`.

Reports will always upload, regardless of test failures, as long as the action is not cancelled.

> **Note**
> To read them you will need read access to Azure CIP.

Makes use of a Service Principal account to authenticate to Azure

**Notes**
The following need to be completed before this PR can be merged:

- [x] Blob storage needs to be configured in Azure for reports to be uploaded to
- [x] ZAP_API_KEY secret will need adding to repository secrets (message me separately for info)