### PR TITLE
138587: Get Establishment information from last trust record via gias…

### DIFF
--- a/TramsDataApi/Gateways/ITrustGateway.cs
+++ b/TramsDataApi/Gateways/ITrustGateway.cs
@@ -7,6 +7,12 @@ namespace TramsDataApi.Gateways
     public interface ITrustGateway
     {
         Group GetGroupByUkPrn(string ukPrn);
+        /// <summary>
+        /// Returns the most recent group record should there be two records with the same UKPRN
+        /// </summary>
+        /// <param name="ukPrn"></param>
+        /// <returns></returns>
+        Group GetLatestGroupByUkPrn(string ukPrn);
         Trust GetIfdTrustByGroupId(string groupId);
         Trust GetIfdTrustByRID(string RID);
         IList<Trust> GetIfdTrustsByTrustRef(string[] trustRefs);

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -22,7 +22,12 @@ namespace TramsDataApi.Gateways
          return _dbContext.Group.FirstOrDefault(g => g.Ukprn == ukPrn);
       }
 
-      public Trust GetIfdTrustByGroupId(string groupId)
+        public Group GetLatestGroupByUkPrn(string ukPrn)
+        {
+            return _dbContext.Group.OrderByDescending(f=> f.GroupUid).FirstOrDefault(g => g.Ukprn == ukPrn);
+        }
+
+        public Trust GetIfdTrustByGroupId(string groupId)
       {
          return _dbContext.Trust.FirstOrDefault(t => t.TrustRef == groupId);
       }
@@ -84,5 +89,7 @@ namespace TramsDataApi.Gateways
         {
             return _dbContext.TrustMasterData.FirstOrDefault(t => t.GroupID == groupId);
         }
+
+ 
     }
 }

--- a/TramsDataApi/UseCases/GetMstrTrustByUkprn.cs
+++ b/TramsDataApi/UseCases/GetMstrTrustByUkprn.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using TramsDataApi.Factories;
 using TramsDataApi.Gateways;
 using TramsDataApi.ResponseModels;
@@ -8,20 +9,24 @@ namespace TramsDataApi.UseCases
     {
         private readonly ITrustGateway _trustGateway;
         private readonly IGetEstablishmentsByTrustUid _getEstablishmentsByTrustUid;
+        private readonly ILogger<GetMstrTrustByUkprn> _logger;
 
-        public GetMstrTrustByUkprn(ITrustGateway trustGateway, IGetEstablishmentsByTrustUid getEstablishmentsByTrustUid)
+        public GetMstrTrustByUkprn(ITrustGateway trustGateway, IGetEstablishmentsByTrustUid getEstablishmentsByTrustUid, ILogger<GetMstrTrustByUkprn> logger)
         {
             _trustGateway = trustGateway;
             _getEstablishmentsByTrustUid = getEstablishmentsByTrustUid;
+            _logger = logger;
         }
         
         public MasterTrustResponse Execute(string ukprn)
         {
-            var group = _trustGateway.GetGroupByUkPrn(ukprn);
+
+            var group = _trustGateway.GetLatestGroupByUkPrn(ukprn);
             if (group == null)
             {
                 return null;
             }
+            _logger.LogInformation("GetMstrTrustByUkprn: Found group with id {GroupUid}", group.GroupUid);
 
             var trust = _trustGateway.GetMstrTrustByGroupId(group.GroupId);
             var establishments = _getEstablishmentsByTrustUid.Execute(group.GroupUid);


### PR DESCRIPTION
**What is the change?**
Amend the way Api returns information from gias.group table when there are records with the same UKPRN

**Why do we need the change?**
Ensure that any Establishment information is returned in the Api response as well as Companies House and Group Type

**What is the impact?**
ReCAST is inconsistently showing Trust information due to the response from the Academies Api

**Azure DevOps Ticket**
[138587](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/138587)