### PR TITLE
Add legacy Cypress tests for v1, v2 and v3 endpoints

### DIFF
--- a/CypressTests/cypress/e2e/v1/healthchecks.cy.js
+++ b/CypressTests/cypress/e2e/v1/healthchecks.cy.js
@@ -1,22 +1,19 @@
 describe("Health and Database Checks", () => {
-  let apiKey = Cypress.env('apiKey');
+  let apiKey = Cypress.env('apiKey')
   let url = Cypress.env('url')
 
   context('Health check endpoint', () => {
     it('should return a healthy response', () => {
       cy.api({
-        method: 'GET',
-        failOnStatusCode: false,
-        url: url + "/HealthCheck",
+        url: `${url}/HealthCheck`,
         headers: {
           ApiKey: apiKey,
           "Content-type": "application/json"
         }
       })
         .then((response) => {
-          expect(response.body).to.contain('Health check ok');
-          expect(response.status).to.eq(200);
-          cy.log(JSON.stringify(response.body));
+          expect(response.body).to.contain('Health check ok')
+          expect(response.status).to.eq(200)
         })
     })
   })
@@ -24,18 +21,15 @@ describe("Health and Database Checks", () => {
   context('Database check endpoint', () => {
     it('should return a healthy response', () => {
       cy.api({
-        method: 'GET',
-        failOnStatusCode: false,
-        url: url + "check_db",
+        url: `${url}/check_db`,
         headers: {
           ApiKey: apiKey,
           "Content-type": "application/json"
         }
       })
         .then((response) => {
-          expect(response.status).to.eq(200);
-          expect(response.body).to.eq(true);
-          cy.log("Database Check = " + JSON.stringify(response.body));
+          expect(response.status).to.eq(200)
+          expect(response.body).to.eq(true)
         })
     })
   })

--- a/CypressTests/cypress/e2e/v1/keyStagePerformance.cy.js
+++ b/CypressTests/cypress/e2e/v1/keyStagePerformance.cy.js
@@ -1,0 +1,24 @@
+describe('Key Stage Performance endpoint tests', () => {
+
+  const apiKey = Cypress.env('apiKey');
+  const url = Cypress.env('url')
+  const urn = '100000'
+  const schoolName = 'The Aldgate School'
+
+  it('Returns education performance data when URN supplied', () => {
+
+    cy.api({
+      method: 'GET',
+      url: `${url}/educationPerformance/${urn}`,
+      headers: {
+        ApiKey: apiKey,
+        "Content-type": "application/json"
+      }
+    })
+      .then((response) => {
+        expect(response.status).to.eq(200)
+        expect(response.body.schoolName).to.eq(schoolName)
+        expect(response.body).to.include.keys('schoolName', 'keyStage1', 'keyStage2', 'keyStage4', 'keyStage5')
+      })
+  })
+})

--- a/CypressTests/cypress/e2e/v1/keyStagePerformance.cy.js
+++ b/CypressTests/cypress/e2e/v1/keyStagePerformance.cy.js
@@ -1,6 +1,6 @@
 describe('Key Stage Performance endpoint tests', () => {
 
-  const apiKey = Cypress.env('apiKey');
+  const apiKey = Cypress.env('apiKey')
   const url = Cypress.env('url')
   const urn = '100000'
   const schoolName = 'The Aldgate School'

--- a/CypressTests/cypress/e2e/v2/baselineTracker.cy.js
+++ b/CypressTests/cypress/e2e/v2/baselineTracker.cy.js
@@ -1,0 +1,27 @@
+describe("Baseline Tracker endpoint", () => {
+
+  const apiKey = Cypress.env('apiKey')
+  const baseUrlV2 = `${Cypress.env('url')}/v2`
+  
+  it("Should return a list of baseline trackers when default parameters set", () => {
+
+    // TODO change url endpoint when spelling mistake resolved
+    cy.api({
+      method: 'GET',
+      url: `${baseUrlV2}/basline-tracker`,
+      qs: {
+        page: 1,
+        count: 50
+      },
+      headers: {
+        ApiKey: apiKey,
+        "Content-type": "application/json"
+      }
+    })
+      .then((response) => {
+        expect(response.status).to.eq(200)
+        expect(response.body.data).to.have.lengthOf.at.least(1).and.lengthOf.at.most(50)
+      })
+  })
+
+})

--- a/CypressTests/cypress/e2e/v2/fssProjects.cy.js
+++ b/CypressTests/cypress/e2e/v2/fssProjects.cy.js
@@ -1,7 +1,7 @@
 /// <reference types="Cypress"/>
 describe("Free Schools Store endpoint", () => {
 
-  const apiKey = Cypress.env('apiKey');
+  const apiKey = Cypress.env('apiKey')
   const url = Cypress.env('url')
   
   it("Should return a valid 200 response", () => {

--- a/CypressTests/cypress/e2e/v2/fssProjects.cy.js
+++ b/CypressTests/cypress/e2e/v2/fssProjects.cy.js
@@ -2,11 +2,11 @@
 describe("Free Schools Store endpoint", () => {
 
   const apiKey = Cypress.env('apiKey')
-  const url = Cypress.env('url')
+  const baseUrlV2 = `${Cypress.env('url')}/v2`
   
   it("Should return a valid 200 response", () => {
     cy.api({
-      url: url + "/v2/fss/projects",
+      url: `${baseUrlV2}/fss/projects`,
       headers: {
         ApiKey: apiKey,
       }
@@ -16,7 +16,7 @@ describe("Free Schools Store endpoint", () => {
   it("Should return a valid 401 response when omitting API key", () => {
     cy.api({
       failOnStatusCode: false,
-      url: url + "/v2/fss/projects",
+      url: `${baseUrlV2}/fss/projects`,
       headers: {
         ApiKey: '',
       }

--- a/CypressTests/cypress/e2e/v3/trusts.cy.js
+++ b/CypressTests/cypress/e2e/v3/trusts.cy.js
@@ -1,6 +1,6 @@
 describe('Trusts endpoints tests', () => {
 
-  const apiKey = Cypress.env('apiKey');
+  const apiKey = Cypress.env('apiKey')
   const baseUrlV3 = `${Cypress.env('url')}/v3`
   const companiesHouseNumber = '11082297'
   const ukprn = '10067112'
@@ -23,7 +23,7 @@ describe('Trusts endpoints tests', () => {
         }
       })
         .then((response) => {
-          expect(response.status).to.eq(200);
+          expect(response.status).to.eq(200)
           expect(response.body.data).to.have.lengthOf.at.least(1).and.lengthOf.at.most(50)
           expect(response.body.paging.page).to.eq(1)
         })
@@ -45,7 +45,7 @@ describe('Trusts endpoints tests', () => {
         }
       })
         .then((response) => {
-          expect(response.status).to.eq(200);
+          expect(response.status).to.eq(200)
           expect(response.body.data[0].groupName).to.eq(groupName)
         })
     })
@@ -66,7 +66,7 @@ describe('Trusts endpoints tests', () => {
         }
       })
         .then((response) => {
-          expect(response.status).to.eq(200);
+          expect(response.status).to.eq(200)
           expect(response.body.data[0].groupName).to.eq(groupName)
         })
     })
@@ -87,7 +87,7 @@ describe('Trusts endpoints tests', () => {
         }
       })
         .then((response) => {
-          expect(response.status).to.eq(200);
+          expect(response.status).to.eq(200)
           expect(response.body.data[0].groupName).to.eq(groupName)
           expect(response.body.data[0].companiesHouseNumber).to.eq(companiesHouseNumber)
         })
@@ -107,7 +107,7 @@ describe('Trusts endpoints tests', () => {
         }
       })
         .then((response) => {
-          expect(response.status).to.eq(200);
+          expect(response.status).to.eq(200)
           expect(response.body.data).to.include.keys('trustData', 'giasData', 'establishments')
           expect(response.body.data.giasData.groupName).to.eq(groupName)
         })

--- a/CypressTests/cypress/e2e/v3/trusts.cy.js
+++ b/CypressTests/cypress/e2e/v3/trusts.cy.js
@@ -1,0 +1,116 @@
+describe('Trusts endpoints tests', () => {
+
+  const apiKey = Cypress.env('apiKey');
+  const baseUrlV3 = `${Cypress.env('url')}/v3`
+  const companiesHouseNumber = '11082297'
+  const ukprn = '10067112'
+  const groupName = 'SOUTH YORK MULTI ACADEMY TRUST'
+
+  context('Search Trusts', () => {
+    
+    it('should return a list of trusts when default search parameters set', () => {
+
+      cy.api({
+        method: 'GET',
+        url: `${baseUrlV3}/trusts`,
+        qs: {
+          page: 1,
+          count: 50
+        },
+        headers: {
+          ApiKey: apiKey,
+          "Content-type": "application/json"
+        }
+      })
+        .then((response) => {
+          expect(response.status).to.eq(200);
+          expect(response.body.data).to.have.lengthOf.at.least(1).and.lengthOf.at.most(50)
+          expect(response.body.paging.page).to.eq(1)
+        })
+    })
+
+    it('should return a single trust when group name set', () => {
+
+      cy.api({
+        method: 'GET',
+        url: `${baseUrlV3}/trusts`,
+        qs: {
+          groupName: groupName,
+          page: 1,
+          count: 50
+        },
+        headers: {
+          ApiKey: apiKey,
+          "Content-type": "application/json"
+        }
+      })
+        .then((response) => {
+          expect(response.status).to.eq(200);
+          expect(response.body.data[0].groupName).to.eq(groupName)
+        })
+    })
+
+    it('should return a single trust when UKPRN set', () => {
+
+      cy.api({
+        method: 'GET',
+        url: `${baseUrlV3}/trusts`,
+        qs: {
+          ukPrn: ukprn,
+          page: 1,
+          count: 50
+        },
+        headers: {
+          ApiKey: apiKey,
+          "Content-type": "application/json"
+        }
+      })
+        .then((response) => {
+          expect(response.status).to.eq(200);
+          expect(response.body.data[0].groupName).to.eq(groupName)
+        })
+    })
+
+    it('should return a single trust when Companies House Number set', () => {
+
+      cy.api({
+        method: 'GET',
+        url: `${baseUrlV3}/trusts`,
+        qs: {
+          companiesHouseNumber: companiesHouseNumber,
+          page: 1,
+          count: 50
+        },
+        headers: {
+          ApiKey: apiKey,
+          "Content-type": "application/json"
+        }
+      })
+        .then((response) => {
+          expect(response.status).to.eq(200);
+          expect(response.body.data[0].groupName).to.eq(groupName)
+          expect(response.body.data[0].companiesHouseNumber).to.eq(companiesHouseNumber)
+        })
+    })
+  })
+
+  context('Get Trust by UKPRN', () => {
+    
+    it('should return a single trust when UKPRN set', () => {
+
+      cy.api({
+        method: 'GET',
+        url: `${baseUrlV3}/trust/${ukprn}`,
+        headers: {
+          ApiKey: apiKey,
+          "Content-type": "application/json"
+        }
+      })
+        .then((response) => {
+          expect(response.status).to.eq(200);
+          expect(response.body.data).to.include.keys('trustData', 'giasData', 'establishments')
+          expect(response.body.data.giasData.groupName).to.eq(groupName)
+        })
+    })
+  })
+})

--- a/CypressTests/cypress/e2e/v4/trusts.cy.js
+++ b/CypressTests/cypress/e2e/v4/trusts.cy.js
@@ -1,6 +1,6 @@
 describe('Trusts endpoints tests', () => {
 
-  const apiKey = Cypress.env('apiKey');
+  const apiKey = Cypress.env('apiKey')
   const baseUrlV4 = `${Cypress.env('url')}/v4`
   const companiesHouseNumber = '11082297'
   const ukprns = ['10067112', '10067113']
@@ -24,7 +24,7 @@ describe('Trusts endpoints tests', () => {
         }
       })
         .then((response) => {
-          expect(response.status).to.eq(200);
+          expect(response.status).to.eq(200)
           expect(response.body.data).to.have.lengthOf.at.least(1).and.lengthOf.at.most(10)
           expect(response.body.paging.page).to.eq(1)
         })
@@ -46,7 +46,7 @@ describe('Trusts endpoints tests', () => {
         }
       })
         .then((response) => {
-          expect(response.status).to.eq(200);
+          expect(response.status).to.eq(200)
           expect(response.body.data[0].name).to.eq(groupName)
         })
     })
@@ -67,7 +67,7 @@ describe('Trusts endpoints tests', () => {
         }
       })
         .then((response) => {
-          expect(response.status).to.eq(200);
+          expect(response.status).to.eq(200)
           expect(response.body.data[0].name).to.eq(groupName)
         })
     })
@@ -88,7 +88,7 @@ describe('Trusts endpoints tests', () => {
         }
       })
         .then((response) => {
-          expect(response.status).to.eq(200);
+          expect(response.status).to.eq(200)
           expect(response.body.data[0].name).to.eq(groupName)
           expect(response.body.data[0].companiesHouseNumber).to.eq(companiesHouseNumber)
         })
@@ -108,7 +108,7 @@ describe('Trusts endpoints tests', () => {
         }
       })
         .then((response) => {
-          expect(response.status).to.eq(200);
+          expect(response.status).to.eq(200)
           expect(response.body.name).to.eq(groupName)
         })
     })
@@ -130,7 +130,7 @@ describe('Trusts endpoints tests', () => {
         }
       })
         .then((response) => {
-          expect(response.status).to.eq(200);
+          expect(response.status).to.eq(200)
           expect(response.body[0].name).to.eq(groupName)
           expect(response.body[0].ukprn).to.eq(ukprns[0])
         })
@@ -153,7 +153,7 @@ describe('Trusts endpoints tests', () => {
         }
       })
         .then((response) => {
-          expect(response.status).to.eq(200);
+          expect(response.status).to.eq(200)
           // Response isn't in UKPRN order
           expect(response.body[1].name).to.eq(groupName)
           expect(response.body[1].ukprn).to.eq(ukprns[0])
@@ -176,7 +176,7 @@ describe('Trusts endpoints tests', () => {
         }
       })
         .then((response) => {
-          expect(response.status).to.eq(200);
+          expect(response.status).to.eq(200)
           expect(response.body.name).to.eq(groupName)
           expect(response.body.companiesHouseNumber).to.eq(companiesHouseNumber)
         })
@@ -196,7 +196,7 @@ describe('Trusts endpoints tests', () => {
         }
       })
         .then((response) => {
-          expect(response.status).to.eq(200);
+          expect(response.status).to.eq(200)
           expect(response.body.name).to.eq(groupName)
           expect(response.body.referenceNumber).to.eq(trustReferenceNumber)
         })

--- a/CypressTests/cypress/plugins/index.js
+++ b/CypressTests/cypress/plugins/index.js
@@ -12,7 +12,7 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-const { generateZapHTMLReport } = require('./generateZapReport');
+const { generateZapHTMLReport } = require('./generateZapReport')
 
 /**
  * @type {Cypress.PluginConfig}

--- a/CypressTests/cypress/support/commands.js
+++ b/CypressTests/cypress/support/commands.js
@@ -26,6 +26,6 @@
 
 
 
-import { validateSchema } from "./validate-schema-command";
+import { validateSchema } from "./validate-schema-command"
 
-Cypress.Commands.add("validateSchema", validateSchema);
+Cypress.Commands.add("validateSchema", validateSchema)

--- a/CypressTests/cypress/support/validate-schema-command.js
+++ b/CypressTests/cypress/support/validate-schema-command.js
@@ -1,28 +1,28 @@
-import Ajv from "ajv";
+import Ajv from "ajv"
 import addFormats from "ajv-formats"
 
 // error message
 const getSchemaError = (getAjvError) => {
   return cy.wrap(
     `Field: ${getAjvError[0]["dataPath"]} is invalid. Cause: ${getAjvError[0]["message"]}`
-  );
-};
+  )
+}
 
 // commands function
 export const validateSchema = (schema, response) => {
   
   const ajv = new Ajv()
   addFormats(ajv)
-  const validate = ajv.compile(schema);
+  const validate = ajv.compile(schema)
 
-  const valid = validate(response);
+  const valid = validate(response)
   console.log(validate.errors)
 
   if (!valid) {
     getSchemaError(validate.errors).then((schemaError) => {
-      throw new Error(schemaError);
-    });
+      throw new Error(schemaError)
+    })
   } else {
-    cy.log("Schema validated!");
+    cy.log("Schema validated!")
   }
-};
+}


### PR DESCRIPTION
Adds tests for the following endpoints:

v1
- `keyStagePerformance`

v2
- `baseline-tracker`

v3
- `trusts`

also removes unnecessary `;`s from end of commands to appease eslint and renames files for consistency across tests