### PR TITLE
152436 Allow Trusts that do not have a status of Open to be searched for

### DIFF
--- a/Dfe.Academies.Api.Infrastructure/Repositories/TrustRepository.cs
+++ b/Dfe.Academies.Api.Infrastructure/Repositories/TrustRepository.cs
@@ -43,7 +43,7 @@ public async Task<Trust?> GetTrustByCompaniesHouseNumber(string companiesHouseNu
             return trusts;
         }
 
-        public async Task<(List<Trust>, int)> Search(int page, int count, string? name, string? ukPrn, string? companiesHouseNumber, string status, CancellationToken cancellationToken)
+        public async Task<(List<Trust>, int)> Search(int page, int count, string? name, string? ukPrn, string? companiesHouseNumber, TrustStatus status, CancellationToken cancellationToken)
         {
             if (name == null && ukPrn == null && companiesHouseNumber == null)
             {
@@ -62,7 +62,7 @@ public async Task<Trust?> GetTrustByCompaniesHouseNumber(string companiesHouseNu
                               trust.TrustType.Name == "Multi-academy trust"
                            ));
             
-            if (status == "Open")
+            if (status == TrustStatus.Open)
             {
                 filteredGroups = filteredGroups.Where(trust => trust.TrustStatus == "Open");
             }

--- a/Dfe.Academies.Application.Tests/Queries/Trust/TrustQueriesTests.cs
+++ b/Dfe.Academies.Application.Tests/Queries/Trust/TrustQueriesTests.cs
@@ -54,7 +54,9 @@ namespace Dfe.Academies.Application.Tests.Queries.Trust
             // Arrange
             var trusts = _fixture.Create<List<Domain.Trust.Trust>>();
             var mockRepo = new Mock<ITrustRepository>();
-            mockRepo.Setup(x => x.Search(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult((trusts, trusts.Count)));
+            mockRepo.Setup(x => x.Search(
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult((trusts, trusts.Count))
+            );
 
             var trustQueries = new TrustQueries(mockRepo.Object);
             int page = 0;
@@ -62,6 +64,7 @@ namespace Dfe.Academies.Application.Tests.Queries.Trust
             string name = null;
             string ukPrn = null;
             string companiesHouseNumber = null;
+            string status = "Open";
             CancellationToken cancellationToken = default(global::System.Threading.CancellationToken);
 
             // Act
@@ -71,6 +74,7 @@ namespace Dfe.Academies.Application.Tests.Queries.Trust
                 name,
                 ukPrn,
                 companiesHouseNumber,
+                status,
                 cancellationToken);
 
             // Assert

--- a/Dfe.Academies.Application.Tests/Queries/Trust/TrustQueriesTests.cs
+++ b/Dfe.Academies.Application.Tests/Queries/Trust/TrustQueriesTests.cs
@@ -55,7 +55,7 @@ namespace Dfe.Academies.Application.Tests.Queries.Trust
             var trusts = _fixture.Create<List<Domain.Trust.Trust>>();
             var mockRepo = new Mock<ITrustRepository>();
             mockRepo.Setup(x => x.Search(
-                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult((trusts, trusts.Count))
+                It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TrustStatus>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult((trusts, trusts.Count))
             );
 
             var trustQueries = new TrustQueries(mockRepo.Object);
@@ -64,7 +64,7 @@ namespace Dfe.Academies.Application.Tests.Queries.Trust
             string name = null;
             string ukPrn = null;
             string companiesHouseNumber = null;
-            string status = "Open";
+            TrustStatus status = TrustStatus.Open;
             CancellationToken cancellationToken = default(global::System.Threading.CancellationToken);
 
             // Act

--- a/Dfe.Academies.Application/Trust/ITrustQueries.cs
+++ b/Dfe.Academies.Application/Trust/ITrustQueries.cs
@@ -1,4 +1,5 @@
 ﻿using Dfe.Academies.Contracts.V4.Trusts;
+using Dfe.Academies.Domain.Trust;
 
 namespace Dfe.Academies.Application.Trust
 {
@@ -8,6 +9,6 @@ namespace Dfe.Academies.Application.Trust
         Task<TrustDto?> GetByCompaniesHouseNumber(string companiesHouseNumber, CancellationToken cancellationToken);
         Task<TrustDto?> GetByTrustReferenceNumber(string trustReferenceNumber, CancellationToken cancellationToken);
         Task<List<TrustDto>> GetByUkprns(string[] ukprns, CancellationToken cancellationToken);
-        Task<(List<TrustDto>, int)> Search(int page, int count, string name, string ukPrn, string companiesHouseNumber, string status, CancellationToken cancellationToken);
+        Task<(List<TrustDto>, int)> Search(int page, int count, string name, string ukPrn, string companiesHouseNumber, TrustStatus status, CancellationToken cancellationToken);
     }
 }

--- a/Dfe.Academies.Application/Trust/ITrustQueries.cs
+++ b/Dfe.Academies.Application/Trust/ITrustQueries.cs
@@ -8,6 +8,6 @@ namespace Dfe.Academies.Application.Trust
         Task<TrustDto?> GetByCompaniesHouseNumber(string companiesHouseNumber, CancellationToken cancellationToken);
         Task<TrustDto?> GetByTrustReferenceNumber(string trustReferenceNumber, CancellationToken cancellationToken);
         Task<List<TrustDto>> GetByUkprns(string[] ukprns, CancellationToken cancellationToken);
-        Task<(List<TrustDto>, int)> Search(int page, int count, string name, string ukPrn, string companiesHouseNumber, CancellationToken cancellationToken);
+        Task<(List<TrustDto>, int)> Search(int page, int count, string name, string ukPrn, string companiesHouseNumber, string status, CancellationToken cancellationToken);
     }
 }

--- a/Dfe.Academies.Application/Trust/TrustQueries.cs
+++ b/Dfe.Academies.Application/Trust/TrustQueries.cs
@@ -23,7 +23,7 @@ namespace Dfe.Academies.Application.Trust
             return trust == null ? null : MapToTrustDto(trust);
         }
 
-        public async Task<(List<TrustDto>, int)> Search(int page, int count, string name, string ukPrn, string companiesHouseNumber, string status, CancellationToken cancellationToken)
+        public async Task<(List<TrustDto>, int)> Search(int page, int count, string name, string ukPrn, string companiesHouseNumber, TrustStatus status, CancellationToken cancellationToken)
         {
             var (trusts, recordCount) = await _trustRepository.Search(page, count, name, ukPrn, companiesHouseNumber, status, cancellationToken).ConfigureAwait(false);
 

--- a/Dfe.Academies.Application/Trust/TrustQueries.cs
+++ b/Dfe.Academies.Application/Trust/TrustQueries.cs
@@ -23,9 +23,9 @@ namespace Dfe.Academies.Application.Trust
             return trust == null ? null : MapToTrustDto(trust);
         }
 
-        public async Task<(List<TrustDto>, int)> Search(int page, int count, string name, string ukPrn, string companiesHouseNumber, CancellationToken cancellationToken)
+        public async Task<(List<TrustDto>, int)> Search(int page, int count, string name, string ukPrn, string companiesHouseNumber, string status, CancellationToken cancellationToken)
         {
-            var (trusts, recordCount) = await _trustRepository.Search(page, count, name, ukPrn, companiesHouseNumber, cancellationToken).ConfigureAwait(false);
+            var (trusts, recordCount) = await _trustRepository.Search(page, count, name, ukPrn, companiesHouseNumber, status, cancellationToken).ConfigureAwait(false);
 
             return (trusts.Select(x => MapToTrustDto(x)).ToList(), recordCount);
         }

--- a/Dfe.Academies.Domain/Trust/ITrustRepository.cs
+++ b/Dfe.Academies.Domain/Trust/ITrustRepository.cs
@@ -6,7 +6,7 @@
         Task<Trust?> GetTrustByCompaniesHouseNumber(string companiesHouseNumber, CancellationToken cancellationToken);
         Task<Trust?> GetTrustByTrustReferenceNumber(string trustReferenceNumber, CancellationToken cancellationToken);
         Task<List<Trust>> GetTrustsByUkprns(string[] ukprns, CancellationToken cancellationToken);
-        Task<(List<Trust>, int)> Search(int page, int count, string name, string ukPrn,
-         string companiesHouseNumber, CancellationToken cancellationToken);
+        Task<(List<Trust>, int)> Search(int page, int count, string? name, string? ukPrn,
+         string? companiesHouseNumber, string status, CancellationToken cancellationToken);
     }
 }

--- a/Dfe.Academies.Domain/Trust/ITrustRepository.cs
+++ b/Dfe.Academies.Domain/Trust/ITrustRepository.cs
@@ -7,6 +7,6 @@
         Task<Trust?> GetTrustByTrustReferenceNumber(string trustReferenceNumber, CancellationToken cancellationToken);
         Task<List<Trust>> GetTrustsByUkprns(string[] ukprns, CancellationToken cancellationToken);
         Task<(List<Trust>, int)> Search(int page, int count, string? name, string? ukPrn,
-         string? companiesHouseNumber, string status, CancellationToken cancellationToken);
+         string? companiesHouseNumber, TrustStatus status, CancellationToken cancellationToken);
     }
 }

--- a/Dfe.Academies.Domain/Trust/TrustStatus.cs
+++ b/Dfe.Academies.Domain/Trust/TrustStatus.cs
@@ -1,0 +1,7 @@
+﻿namespace Dfe.Academies.Domain.Trust;
+
+public enum TrustStatus
+{
+    Open,
+    All
+}

--- a/TramsDataApi.Test/Integration/V4/TrustV4IntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/V4/TrustV4IntegrationTests.cs
@@ -359,7 +359,7 @@ namespace TramsDataApi.Test.Integration.V4
             context.Trusts.AddRange(trustData);
             await context.SaveChangesAsync();
 
-            var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/trusts?groupName={closedTrust.Name}");
+            var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/trusts?groupName={closedTrust.Name}&status=Open");
             trustResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
             var trustContent = await trustResponse.Content.ReadFromJsonAsync<PagedDataResponse<TrustDto>>();
@@ -375,6 +375,23 @@ namespace TramsDataApi.Test.Integration.V4
             allTrustContent.Data.Should().HaveCount(1);
             
             allTrustContent.Data.Should().Contain(trust => trust.Ukprn == closedTrust.UKPRN);
+        }
+        
+        [Fact]
+        public async Task Get_SearchByStatus_WIthIncorrectStatus_Returns_400()
+        {
+            using var context = _apiFixture.GetMstrContext();
+
+            var trustData = BuildSmallTrustSet();
+            var closedTrust = trustData.First();
+            closedTrust.TrustStatus = "Closed";
+
+            context.Trusts.AddRange(trustData);
+            await context.SaveChangesAsync();
+
+            var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/trusts?groupName={closedTrust.Name}&status=Wrong");
+            trustResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
         }
 
         [Fact]

--- a/TramsDataApi.Test/Integration/V4/TrustV4IntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/V4/TrustV4IntegrationTests.cs
@@ -346,6 +346,36 @@ namespace TramsDataApi.Test.Integration.V4
 
             actualTrust.Ukprn.Should().Be(selectedTrust.UKPRN);
         }
+        
+        [Fact]
+        public async Task Get_SearchByStatus_Returns_Ok()
+        {
+            using var context = _apiFixture.GetMstrContext();
+
+            var trustData = BuildSmallTrustSet();
+            var closedTrust = trustData.First();
+            closedTrust.TrustStatus = "Closed";
+
+            context.Trusts.AddRange(trustData);
+            await context.SaveChangesAsync();
+
+            var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/trusts?groupName={closedTrust.Name}");
+            trustResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var trustContent = await trustResponse.Content.ReadFromJsonAsync<PagedDataResponse<TrustDto>>();
+
+            trustContent.Data.Should().HaveCount(0);
+            trustContent.Data.Should().NotContain(trust => trust.Ukprn == closedTrust.UKPRN);
+            
+            var allTrustResponse = await _client.GetAsync($"{_apiUrlPrefix}/trusts?groupName={closedTrust.Name}&status=All");
+            trustResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var allTrustContent = await allTrustResponse.Content.ReadFromJsonAsync<PagedDataResponse<TrustDto>>();
+
+            allTrustContent.Data.Should().HaveCount(1);
+            
+            allTrustContent.Data.Should().Contain(trust => trust.Ukprn == closedTrust.UKPRN);
+        }
 
         [Fact]
         public async Task Get_SearchByCriteria_NoTrustExists_Returns_Empty_Ok()

--- a/TramsDataApi/Controllers/V4/TrustsController.cs
+++ b/TramsDataApi/Controllers/V4/TrustsController.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Dfe.Academies.Application.Trust;
 using Dfe.Academies.Contracts.V4;
 using Dfe.Academies.Contracts.V4.Trusts;
+using Dfe.Academies.Domain.Trust;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
@@ -125,7 +126,7 @@ namespace TramsDataApi.Controllers.V4
         [Route("trusts")]        
         [SwaggerOperation(Summary = "Search Trusts", Description = "Returns a list of Trusts based on search criteria.")]
         [SwaggerResponse(200, "Successfully executed the search and returned Trusts.")]
-        public async Task<ActionResult<PagedDataResponse<TrustDto>>> SearchTrusts(string groupName, string ukPrn, string companiesHouseNumber, CancellationToken cancellationToken, int page = 1, int count = 10, string status = "Open")
+        public async Task<ActionResult<PagedDataResponse<TrustDto>>> SearchTrusts(string groupName, string ukPrn, string companiesHouseNumber, CancellationToken cancellationToken, int page = 1, int count = 10, TrustStatus status = TrustStatus.Open)
         {
             _logger.LogInformation(
                 "Searching for trusts by groupName \"{name}\", UKPRN \"{prn}\", companiesHouseNumber \"{number}\", page {page}, count {count}",

--- a/TramsDataApi/Controllers/V4/TrustsController.cs
+++ b/TramsDataApi/Controllers/V4/TrustsController.cs
@@ -119,19 +119,20 @@ namespace TramsDataApi.Controllers.V4
         /// <param name="cancellationToken"></param>
         /// <param name="page">Pagination page.</param>
         /// <param name="count">Number of results per page.</param>
+        /// <param name="status">The status of the trust, defaults to "Open"</param>
         /// <returns>A list of Trusts that meet the search criteria.</returns>
         [HttpGet]
         [Route("trusts")]        
         [SwaggerOperation(Summary = "Search Trusts", Description = "Returns a list of Trusts based on search criteria.")]
         [SwaggerResponse(200, "Successfully executed the search and returned Trusts.")]
-        public async Task<ActionResult<PagedDataResponse<TrustDto>>> SearchTrusts(string groupName, string ukPrn, string companiesHouseNumber, CancellationToken cancellationToken, int page = 1, int count = 10)
+        public async Task<ActionResult<PagedDataResponse<TrustDto>>> SearchTrusts(string groupName, string ukPrn, string companiesHouseNumber, CancellationToken cancellationToken, int page = 1, int count = 10, string status = "Open")
         {
             _logger.LogInformation(
                 "Searching for trusts by groupName \"{name}\", UKPRN \"{prn}\", companiesHouseNumber \"{number}\", page {page}, count {count}",
                 groupName, ukPrn, companiesHouseNumber, page, count);
 
             var (trusts, recordCount) = await _trustQueries
-                .Search(page, count, groupName, ukPrn, companiesHouseNumber, cancellationToken).ConfigureAwait(false);
+                .Search(page, count, groupName, ukPrn, companiesHouseNumber, status, cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation(
                 "Found {count} trusts for groupName \"{name}\", UKPRN \"{prn}\", companiesHouseNumber \"{number}\", page {page}, count {count}",

--- a/TramsDataApi/Startup.cs
+++ b/TramsDataApi/Startup.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Dfe.Academisation.CorrelationIdMiddleware;
 
 namespace TramsDataApi
@@ -36,7 +37,7 @@ namespace TramsDataApi
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddControllers();
+            services.AddControllers().AddJsonOptions(c => {c.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());});
             services.AddApiVersioning();
             services.AddFeatureManagement();
 


### PR DESCRIPTION
Adds an option to the trust search endpoint to filter to only open trusts or to any trust status.
Default behaviour is retained of only search for open trusts for backwards compatibility, but providing anything other that "Open" will allow you to disable this filter.