### PR TITLE
153650: trusts missing establishments

### DIFF
--- a/TramsDataApi.Test/Extensions/StringExtensionsTests.cs
+++ b/TramsDataApi.Test/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,25 @@
+﻿using TramsDataApi.Extensions;
+using Xunit;
+
+namespace TramsDataApi.Test.Extensions
+{
+    public class StringExtensionsTests
+    {
+        [Theory]
+        [InlineData("123", 123)]
+        [InlineData("456", 456)]
+        [InlineData("0", 0)]
+        [InlineData("-789", -789)]
+        [InlineData("abc", 0)]  // Invalid string
+        [InlineData(null, 0)]   // Null string
+        [InlineData("", 0)]     // Empty string
+        public void ToInt_ReturnsExpectedResult(string input, int expectedResult)
+        {
+            // Act
+            int result = input.ToInt();
+
+            // Assert
+            Assert.Equal(expectedResult, result);
+        }
+    }
+}

--- a/TramsDataApi.Test/Integration/TrustsV3IntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/TrustsV3IntegrationTests.cs
@@ -197,7 +197,7 @@ namespace TramsDataApi.Test.Integration
             string TrustUKPRN = "123456789";
 
             var closedTrustGroup = _fixture.Build<Group>()
-                .With(f => f.GroupUid, "1")
+                .With(f => f.GroupUid, "234")
                 .With(f => f.GroupId, groupID)
                 .With(f=> f.GroupName, TrustName)
                 .With(f => f.Ukprn, TrustUKPRN)
@@ -208,14 +208,14 @@ namespace TramsDataApi.Test.Integration
                 .Create();
 
             var openTrustGroup = _fixture.Build<Group>()
-                .With(f => f.GroupUid, "2")
+                .With(f => f.GroupUid, "1234")
                 .With(f => f.GroupId, groupID)
-                 .With(f => f.GroupName, TrustName)
-                 .With(f => f.Ukprn, TrustUKPRN)
-                 .With(f => f.GroupStatus, "Open")
-                 .With(f => f.GroupStatusCode, "OPEN")
-                 .With(f => f.GroupType, "Multi-academy trust")
-                 .Create();
+                .With(f => f.GroupName, TrustName)
+                .With(f => f.Ukprn, TrustUKPRN)
+                .With(f => f.GroupStatus, "Open")
+                .With(f => f.GroupStatusCode, "OPEN")
+                .With(f => f.GroupType, "Multi-academy trust")
+                .Create();
 
             _legacyDbContext.Group.AddRange(closedTrustGroup, openTrustGroup);
 

--- a/TramsDataApi/Extensions/StringExtensions.cs
+++ b/TramsDataApi/Extensions/StringExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace TramsDataApi.Extensions
+{
+    public static class StringExtensions
+    {
+        public static int ToInt(this string value)
+        {
+            return int.TryParse(value, out var result) ? result : 0;
+        }
+    }
+}

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -1,14 +1,13 @@
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore;
 using TramsDataApi.DatabaseModels;
 using TramsDataApi.Extensions;
 
 namespace TramsDataApi.Gateways
 {
-   public class TrustGateway : ITrustGateway
+    public class TrustGateway : ITrustGateway
    {
       private readonly LegacyTramsDbContext _dbContext;
 
@@ -24,7 +23,11 @@ namespace TramsDataApi.Gateways
 
         public Group GetLatestGroupByUkPrn(string ukPrn)
         {
-            return _dbContext.Group.OrderByDescending(f=> f.GroupUid).FirstOrDefault(g => g.Ukprn == ukPrn);
+            var group = _dbContext.Group.Where(g => g.Ukprn == ukPrn).ToList();
+
+            var result = group.OrderByDescending(g => g.GroupUid.ToInt()).FirstOrDefault();
+
+            return result;
         }
 
         public Trust GetIfdTrustByGroupId(string groupId)
@@ -90,6 +93,9 @@ namespace TramsDataApi.Gateways
             return _dbContext.TrustMasterData.FirstOrDefault(t => t.GroupID == groupId);
         }
 
- 
+        private static int ToInt(string value)
+        {
+            return int.TryParse(value, out var parsed) ? parsed : 0;
+        }
     }
 }

--- a/TramsDataApi/Gateways/TrustGateway.cs
+++ b/TramsDataApi/Gateways/TrustGateway.cs
@@ -92,10 +92,5 @@ namespace TramsDataApi.Gateways
         {
             return _dbContext.TrustMasterData.FirstOrDefault(t => t.GroupID == groupId);
         }
-
-        private static int ToInt(string value)
-        {
-            return int.TryParse(value, out var parsed) ? parsed : 0;
-        }
     }
 }


### PR DESCRIPTION
logic for ordering by group uid was wrong, because group uid is a string
converted the string to a number, so the ordering works correctly
added utility method for converting strings to numbers to prove all scenarios would work

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/153650