### PR TITLE
Create identifiers endpoint

### DIFF
--- a/Dfe.Academies.Api.Infrastructure/Repositories/TrustRepository.cs
+++ b/Dfe.Academies.Api.Infrastructure/Repositories/TrustRepository.cs
@@ -39,6 +39,14 @@ namespace Dfe.Academies.Infrastructure.Repositories
 
             return trust;
         }
+        
+        public async Task<Trust?> GetTrustByGroupUID(string groupUID, CancellationToken cancellationToken)
+        {
+            var trust = await DefaultIncludes().AsNoTracking()
+                .SingleOrDefaultAsync(x => x.GroupUID == groupUID, cancellationToken).ConfigureAwait(false);
+
+            return trust;
+        }
 
         public async Task<List<Trust>> GetTrustsByUkprns(string[] ukprns, CancellationToken cancellationToken)
         {

--- a/Dfe.Academies.Api.Infrastructure/Repositories/TrustRepository.cs
+++ b/Dfe.Academies.Api.Infrastructure/Repositories/TrustRepository.cs
@@ -39,14 +39,6 @@ namespace Dfe.Academies.Infrastructure.Repositories
 
             return trust;
         }
-        
-        public async Task<Trust?> GetTrustByGroupUID(string groupUID, CancellationToken cancellationToken)
-        {
-            var trust = await DefaultIncludes().AsNoTracking()
-                .SingleOrDefaultAsync(x => x.GroupUID == groupUID, cancellationToken).ConfigureAwait(false);
-
-            return trust;
-        }
 
         public async Task<List<Trust>> GetTrustsByUkprns(string[] ukprns, CancellationToken cancellationToken)
         {

--- a/Dfe.Academies.Api.Infrastructure/Repositories/TrustRepository.cs
+++ b/Dfe.Academies.Api.Infrastructure/Repositories/TrustRepository.cs
@@ -56,6 +56,14 @@ namespace Dfe.Academies.Infrastructure.Repositories
             return trusts;
         }
 
+        public async Task<List<Trust>> GetTrustsByIdentifier(string identifier, CancellationToken cancellationToken)
+        {
+            var trusts = await DefaultIncludes().AsNoTracking().Where(x =>
+                    identifier.Equals(x.UKPRN) || identifier.Equals(x.GroupID) || identifier.Equals(x.GroupUID))
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+            return trusts;
+        }
+
         public async Task<(List<Trust>, int)> Search(int page, int count, string? name, string? ukPrn,
             string? companiesHouseNumber, TrustStatus status, CancellationToken cancellationToken)
         {

--- a/Dfe.Academies.Application/Trust/ITrustQueries.cs
+++ b/Dfe.Academies.Application/Trust/ITrustQueries.cs
@@ -8,7 +8,6 @@ namespace Dfe.Academies.Application.Trust
         Task<TrustDto?> GetByUkprn(string ukprn, CancellationToken cancellationToken);
         Task<TrustDto?> GetByCompaniesHouseNumber(string companiesHouseNumber, CancellationToken cancellationToken);
         Task<TrustDto?> GetByTrustReferenceNumber(string trustReferenceNumber, CancellationToken cancellationToken);
-        Task<TrustDto?> GetByTrustGroupUID(string groupUID, CancellationToken cancellationToken);
         Task<List<TrustDto>> GetByUkprns(string[] ukprns, CancellationToken cancellationToken);
         Task<List<TrustIdentifiers>?> GetTrustIdentifiers(string identifier, CancellationToken cancellationToken);
         Task<(List<TrustDto>, int)> Search(int page, int count, string name, string ukPrn, string companiesHouseNumber,

--- a/Dfe.Academies.Application/Trust/ITrustQueries.cs
+++ b/Dfe.Academies.Application/Trust/ITrustQueries.cs
@@ -8,7 +8,10 @@ namespace Dfe.Academies.Application.Trust
         Task<TrustDto?> GetByUkprn(string ukprn, CancellationToken cancellationToken);
         Task<TrustDto?> GetByCompaniesHouseNumber(string companiesHouseNumber, CancellationToken cancellationToken);
         Task<TrustDto?> GetByTrustReferenceNumber(string trustReferenceNumber, CancellationToken cancellationToken);
+        Task<TrustDto?> GetByTrustGroupUID(string groupUID, CancellationToken cancellationToken);
         Task<List<TrustDto>> GetByUkprns(string[] ukprns, CancellationToken cancellationToken);
-        Task<(List<TrustDto>, int)> Search(int page, int count, string name, string ukPrn, string companiesHouseNumber, TrustStatus status, CancellationToken cancellationToken);
+        Task<List<TrustIdentifiers>?> GetTrustIdentifiers(string identifer, CancellationToken cancellationToken);
+        Task<(List<TrustDto>, int)> Search(int page, int count, string name, string ukPrn, string companiesHouseNumber,
+            TrustStatus status, CancellationToken cancellationToken);
     }
 }

--- a/Dfe.Academies.Application/Trust/ITrustQueries.cs
+++ b/Dfe.Academies.Application/Trust/ITrustQueries.cs
@@ -9,7 +9,7 @@ namespace Dfe.Academies.Application.Trust
         Task<TrustDto?> GetByCompaniesHouseNumber(string companiesHouseNumber, CancellationToken cancellationToken);
         Task<TrustDto?> GetByTrustReferenceNumber(string trustReferenceNumber, CancellationToken cancellationToken);
         Task<List<TrustDto>> GetByUkprns(string[] ukprns, CancellationToken cancellationToken);
-        Task<List<TrustIdentifiers>?> GetTrustIdentifiers(string identifier, CancellationToken cancellationToken);
+        Task<List<TrustIdentifiers>> GetTrustIdentifiers(string identifier, CancellationToken cancellationToken);
         Task<(List<TrustDto>, int)> Search(int page, int count, string name, string ukPrn, string companiesHouseNumber,
             TrustStatus status, CancellationToken cancellationToken);
     }

--- a/Dfe.Academies.Application/Trust/ITrustQueries.cs
+++ b/Dfe.Academies.Application/Trust/ITrustQueries.cs
@@ -10,7 +10,7 @@ namespace Dfe.Academies.Application.Trust
         Task<TrustDto?> GetByTrustReferenceNumber(string trustReferenceNumber, CancellationToken cancellationToken);
         Task<TrustDto?> GetByTrustGroupUID(string groupUID, CancellationToken cancellationToken);
         Task<List<TrustDto>> GetByUkprns(string[] ukprns, CancellationToken cancellationToken);
-        Task<List<TrustIdentifiers>?> GetTrustIdentifiers(string identifer, CancellationToken cancellationToken);
+        Task<List<TrustIdentifiers>?> GetTrustIdentifiers(string identifier, CancellationToken cancellationToken);
         Task<(List<TrustDto>, int)> Search(int page, int count, string name, string ukPrn, string companiesHouseNumber,
             TrustStatus status, CancellationToken cancellationToken);
     }

--- a/Dfe.Academies.Application/Trust/TrustQueries.cs
+++ b/Dfe.Academies.Application/Trust/TrustQueries.cs
@@ -92,13 +92,13 @@ namespace Dfe.Academies.Application.Trust
         
         private static TrustIdentifiers mapToIdentifiers(Domain.Trust.Trust trust)
         {
-            return new TrustIdentifiers(UID: trust.GroupUID, UKPRN: trust.UKPRN, TR: trust.GroupID);
+            return new TrustIdentifiers(UID: trust.GroupUID, UKPRN: trust.UKPRN, TrustReference: trust.GroupID);
         }
     }
 
     public record TrustIdentifiers(
         string? UID,
         string? UKPRN,
-        string? TR
+        string? TrustReference
     );
 }

--- a/Dfe.Academies.Application/Trust/TrustQueries.cs
+++ b/Dfe.Academies.Application/Trust/TrustQueries.cs
@@ -52,12 +52,6 @@ namespace Dfe.Academies.Application.Trust
             return trust == null ? null : MapToTrustDto(trust);
         }
 
-        public async Task<TrustDto?> GetByTrustGroupUID(string groupUID, CancellationToken cancellationToken)
-        {
-            var trust = await _trustRepository.GetTrustByGroupUID(groupUID, cancellationToken).ConfigureAwait(false);
-            return trust == null ? null : MapToTrustDto(trust);
-        }
-
         public async Task<List<TrustIdentifiers>?> GetTrustIdentifiers(string identifier,
             CancellationToken cancellationToken)
         {

--- a/Dfe.Academies.Application/Trust/TrustQueries.cs
+++ b/Dfe.Academies.Application/Trust/TrustQueries.cs
@@ -58,27 +58,10 @@ namespace Dfe.Academies.Application.Trust
             return trust == null ? null : MapToTrustDto(trust);
         }
 
-        public async Task<List<TrustIdentifiers>?> GetTrustIdentifiers(string identifer,
+        public async Task<List<TrustIdentifiers>?> GetTrustIdentifiers(string identifier,
             CancellationToken cancellationToken)
         {
-            var trusts = new List<Domain.Trust.Trust>();
-            
-            var ukprnTrust = await _trustRepository.GetTrustByUkprn(identifer, cancellationToken).ConfigureAwait(false);
-            if (ukprnTrust is not null)
-            {
-                trusts.Add(ukprnTrust);
-            }
-            var trustReferenceTrust = await _trustRepository.GetTrustByTrustReferenceNumber(identifer, cancellationToken)
-                .ConfigureAwait(false);
-            if (trustReferenceTrust is not null)
-            {
-                trusts.Add(trustReferenceTrust);
-            }
-            var groupUIDTrust = await _trustRepository.GetTrustByGroupUID(identifer, cancellationToken).ConfigureAwait(false);
-            if (groupUIDTrust is not null)
-            {
-                trusts.Add(groupUIDTrust);
-            }
+            var trusts = await _trustRepository.GetTrustsByIdentifier(identifier, cancellationToken);
 
             var trustIdentifiersList = trusts.Select(mapToIdentifiers).ToList();
 

--- a/Dfe.Academies.Application/Trust/TrustQueries.cs
+++ b/Dfe.Academies.Application/Trust/TrustQueries.cs
@@ -52,14 +52,14 @@ namespace Dfe.Academies.Application.Trust
             return trust == null ? null : MapToTrustDto(trust);
         }
 
-        public async Task<List<TrustIdentifiers>?> GetTrustIdentifiers(string identifier,
+        public async Task<List<TrustIdentifiers>> GetTrustIdentifiers(string identifier,
             CancellationToken cancellationToken)
         {
             var trusts = await _trustRepository.GetTrustsByIdentifier(identifier, cancellationToken);
 
             var trustIdentifiersList = trusts.Select(mapToIdentifiers).ToList();
 
-            return trustIdentifiersList.Count > 0 ? trustIdentifiersList : null;
+            return trustIdentifiersList.Count > 0 ? trustIdentifiersList : new List<TrustIdentifiers>();
         }
 
         private static TrustDto MapToTrustDto(Domain.Trust.Trust trust)

--- a/Dfe.Academies.Domain/Trust/ITrustRepository.cs
+++ b/Dfe.Academies.Domain/Trust/ITrustRepository.cs
@@ -7,6 +7,7 @@
         Task<Trust?> GetTrustByTrustReferenceNumber(string trustReferenceNumber, CancellationToken cancellationToken);
         Task<Trust?> GetTrustByGroupUID(string groupUID, CancellationToken cancellationToken);
         Task<List<Trust>> GetTrustsByUkprns(string[] ukprns, CancellationToken cancellationToken);
+        Task<List<Trust>> GetTrustsByIdentifier(string identifier, CancellationToken cancellationToken);
         Task<(List<Trust>, int)> Search(int page, int count, string? name, string? ukPrn,
          string? companiesHouseNumber, TrustStatus status, CancellationToken cancellationToken);
     }

--- a/Dfe.Academies.Domain/Trust/ITrustRepository.cs
+++ b/Dfe.Academies.Domain/Trust/ITrustRepository.cs
@@ -5,7 +5,6 @@
         Task<Trust?> GetTrustByUkprn(string ukprn, CancellationToken cancellationToken);
         Task<Trust?> GetTrustByCompaniesHouseNumber(string companiesHouseNumber, CancellationToken cancellationToken);
         Task<Trust?> GetTrustByTrustReferenceNumber(string trustReferenceNumber, CancellationToken cancellationToken);
-        Task<Trust?> GetTrustByGroupUID(string groupUID, CancellationToken cancellationToken);
         Task<List<Trust>> GetTrustsByUkprns(string[] ukprns, CancellationToken cancellationToken);
         Task<List<Trust>> GetTrustsByIdentifier(string identifier, CancellationToken cancellationToken);
         Task<(List<Trust>, int)> Search(int page, int count, string? name, string? ukPrn,

--- a/Dfe.Academies.Domain/Trust/ITrustRepository.cs
+++ b/Dfe.Academies.Domain/Trust/ITrustRepository.cs
@@ -5,6 +5,7 @@
         Task<Trust?> GetTrustByUkprn(string ukprn, CancellationToken cancellationToken);
         Task<Trust?> GetTrustByCompaniesHouseNumber(string companiesHouseNumber, CancellationToken cancellationToken);
         Task<Trust?> GetTrustByTrustReferenceNumber(string trustReferenceNumber, CancellationToken cancellationToken);
+        Task<Trust?> GetTrustByGroupUID(string groupUID, CancellationToken cancellationToken);
         Task<List<Trust>> GetTrustsByUkprns(string[] ukprns, CancellationToken cancellationToken);
         Task<(List<Trust>, int)> Search(int page, int count, string? name, string? ukPrn,
          string? companiesHouseNumber, TrustStatus status, CancellationToken cancellationToken);

--- a/TramsDataApi.Test/Integration/V4/IdentifiersV4IntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/V4/IdentifiersV4IntegrationTests.cs
@@ -38,7 +38,7 @@ public class IdentifiersV4IntegrationTests
         var trustData = BuildSmallTrustSet();
 
         context.Trusts.AddRange(trustData);
-        context.SaveChanges();
+        await context.SaveChangesAsync();
 
         var selectedTrust = trustData.First();
 
@@ -69,7 +69,7 @@ public class IdentifiersV4IntegrationTests
         var trustData = BuildSmallDuplicateTrustSet(idType);
 
         context.Trusts.AddRange(trustData);
-        context.SaveChanges();
+        await context.SaveChangesAsync();
 
         var selectedTrust = trustData.First();
         
@@ -87,6 +87,20 @@ public class IdentifiersV4IntegrationTests
         var trustContent = await trustResponse.Content.ReadFromJsonAsync<TrustIdentifiers[]>();
         trustContent.Length.Should().Be(3);
         AssertIdentifierResponse(trustContent.First(), selectedTrust);
+    }
+    
+    [Fact]
+    public async Task Get_TrustIdentifiers_AndTrustDoesNotExist_Returns_NotFound()
+    {
+        using var context = _apiFixture.GetMstrContext();
+
+        var trustData = BuildSmallTrustSet();
+
+        context.Trusts.AddRange(trustData);
+        await context.SaveChangesAsync();
+
+        var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/noTrustExists");
+        trustResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
     
     private static List<Trust> BuildSmallTrustSet()

--- a/TramsDataApi.Test/Integration/V4/IdentifiersV4IntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/V4/IdentifiersV4IntegrationTests.cs
@@ -87,6 +87,9 @@ public class IdentifiersV4IntegrationTests
         var trustContent = await trustResponse.Content.ReadFromJsonAsync<TrustIdentifiers[]>();
         trustContent.Length.Should().Be(3);
         AssertIdentifierResponse(trustContent.First(), selectedTrust);
+        AssertIdentifierResponse(trustContent[2], selectedTrust);
+        AssertIdentifierResponse(trustContent[3], selectedTrust);
+
     }
     
     [Theory]
@@ -145,6 +148,8 @@ public class IdentifiersV4IntegrationTests
 
         var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/noTrustExists");
         trustResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var trustContent = await trustResponse.Content.ReadFromJsonAsync<List<TrustIdentifiers>>();
+        trustContent.Count.Should().Be(0);
     }
     
     private static List<Trust> BuildSmallTrustSet()

--- a/TramsDataApi.Test/Integration/V4/IdentifiersV4IntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/V4/IdentifiersV4IntegrationTests.cs
@@ -148,8 +148,6 @@ public class IdentifiersV4IntegrationTests
 
         var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/noTrustExists");
         trustResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
-        var trustContent = await trustResponse.Content.ReadFromJsonAsync<List<TrustIdentifiers>>();
-        trustContent.Count.Should().Be(0);
     }
     
     private static List<Trust> BuildSmallTrustSet()

--- a/TramsDataApi.Test/Integration/V4/IdentifiersV4IntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/V4/IdentifiersV4IntegrationTests.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using AutoFixture;
+using Dfe.Academies.Application.Trust;
+using Dfe.Academies.Contracts.V4.Trusts;
+using Dfe.Academies.Domain.Trust;
+using FluentAssertions;
+using TramsDataApi.Test.Fixtures;
+using TramsDataApi.Test.Helpers;
+using Xunit;
+
+namespace TramsDataApi.Test.Integration.V4;
+[Collection(ApiTestCollection.ApiTestCollectionName)]
+public class IdentifiersV4IntegrationTests
+{
+    private readonly HttpClient _client;
+    private static readonly Fixture _autoFixture = new Fixture();
+    private readonly ApiTestFixture _apiFixture;
+
+    private readonly string _apiUrlPrefix = "/v4";
+
+    public IdentifiersV4IntegrationTests(ApiTestFixture fixture)
+    {
+        _apiFixture = fixture;
+        _client = fixture.Client;
+    }
+    
+    [Fact]
+    public async Task Get_TrustIdentifiersByUkPrn_AndTrustExists_Returns_Ok()
+    {
+        using var context = _apiFixture.GetMstrContext();
+
+        var trustData = BuildSmallTrustSet();
+
+        context.Trusts.AddRange(trustData);
+        context.SaveChanges();
+
+        var selectedTrust = trustData.First();
+
+        var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/{selectedTrust.UKPRN}");
+        trustResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var trustContent = await trustResponse.Content.ReadFromJsonAsync<TrustIdentifiers[]>();
+        trustContent.Length.Should().Be(1);
+        AssertIdentifierResponse(trustContent.First(), selectedTrust);
+    }
+    
+    [Fact]
+    public async Task Get_TrustIdentifiersByUID_AndTrustExists_Returns_Ok()
+    {
+        using var context = _apiFixture.GetMstrContext();
+
+        var trustData = BuildSmallTrustSet();
+
+        context.Trusts.AddRange(trustData);
+        context.SaveChanges();
+
+        var selectedTrust = trustData.First();
+
+        var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/{selectedTrust.GroupUID}");
+        trustResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var trustContent = await trustResponse.Content.ReadFromJsonAsync<TrustIdentifiers[]>();
+        trustContent.Length.Should().Be(1);
+        AssertIdentifierResponse(trustContent.First(), selectedTrust);
+    }
+    
+    [Fact]
+    public async Task Get_TrustIdentifiersByGroupID_AndTrustExists_Returns_Ok()
+    {
+        using var context = _apiFixture.GetMstrContext();
+
+        var trustData = BuildSmallTrustSet();
+
+        context.Trusts.AddRange(trustData);
+        context.SaveChanges();
+
+        var selectedTrust = trustData.First();
+
+        var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/{selectedTrust.GroupID}");
+        trustResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var trustContent = await trustResponse.Content.ReadFromJsonAsync<TrustIdentifiers[]>();
+        trustContent.Length.Should().Be(1);
+        AssertIdentifierResponse(trustContent.First(), selectedTrust);
+    }
+    
+    [Fact]
+    public async Task Get_TrustIdentifiersByUKPRN_AndDuplicateTrustsExists_Returns_Ok()
+    {
+        using var context = _apiFixture.GetMstrContext();
+
+        var trustData = BuildSmallDuplicateTrustSet(IdTypes.UKPRN);
+
+        context.Trusts.AddRange(trustData);
+        context.SaveChanges();
+
+        var selectedTrust = trustData.First();
+
+        var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/UKPRN");
+        trustResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var trustContent = await trustResponse.Content.ReadFromJsonAsync<TrustIdentifiers[]>();
+        trustContent.Length.Should().Be(3);
+        AssertIdentifierResponse(trustContent.First(), selectedTrust);
+    }
+    
+    [Fact]
+    public async Task Get_TrustIdentifiersByGroupUID_AndDuplicateTrustsExists_Returns_Ok()
+    {
+        using var context = _apiFixture.GetMstrContext();
+
+        var trustData = BuildSmallDuplicateTrustSet(IdTypes.GroupUID);
+
+        context.Trusts.AddRange(trustData);
+        context.SaveChanges();
+
+        var selectedTrust = trustData.First();
+
+        var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/GroupUID");
+        trustResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var trustContent = await trustResponse.Content.ReadFromJsonAsync<TrustIdentifiers[]>();
+        trustContent.Length.Should().Be(3);
+        AssertIdentifierResponse(trustContent.First(), selectedTrust);
+    }
+    
+    [Fact]
+    public async Task Get_TrustIdentifiersByGroupID_AndDuplicateTrustsExists_Returns_Ok()
+    {
+        using var context = _apiFixture.GetMstrContext();
+
+        var trustData = BuildSmallDuplicateTrustSet(IdTypes.GroupID);
+
+        context.Trusts.AddRange(trustData);
+        context.SaveChanges();
+
+        var selectedTrust = trustData.First();
+
+        var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/GroupID");
+        trustResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var trustContent = await trustResponse.Content.ReadFromJsonAsync<TrustIdentifiers[]>();
+        trustContent.Length.Should().Be(3);
+        AssertIdentifierResponse(trustContent.First(), selectedTrust);
+    }
+    
+    private static List<Trust> BuildSmallTrustSet()
+    {
+        var result = new List<Trust>();
+
+        for (var idx = 0; idx < 3; idx++)
+        {
+            var trust = DatabaseModelBuilder.BuildTrust();
+            result.Add(trust);
+        }
+
+        return result;
+    }
+    
+    private enum IdTypes { GroupID, UKPRN, GroupUID } 
+    
+    private static List<Trust> BuildSmallDuplicateTrustSet(IdTypes id)
+    {
+        var result = new List<Trust>();
+
+        for (var idx = 0; idx < 3; idx++)
+        {
+            var trust = DatabaseModelBuilder.BuildTrust();
+            switch (id)
+            {
+                case IdTypes.GroupID:
+                    trust.GroupID = "GroupID";
+                    break;
+                case IdTypes.UKPRN:
+                    trust.UKPRN = "UKPRN";
+                    break;
+                case IdTypes.GroupUID:
+                    trust.GroupUID = "GroupUID";
+                    break;
+            }
+
+            result.Add(trust);
+        }
+
+        return result;
+    }
+    
+    private static void AssertIdentifierResponse(TrustIdentifiers actual, Trust expected)
+    {
+        actual.TR.Should().Be(expected.GroupID);
+        actual.UKPRN.Should().Be(expected.UKPRN);
+        actual.UID.Should().Be(expected.GroupUID);
+    }
+}

--- a/TramsDataApi.Test/Integration/V4/IdentifiersV4IntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/V4/IdentifiersV4IntegrationTests.cs
@@ -86,9 +86,9 @@ public class IdentifiersV4IntegrationTests
 
         var trustContent = await trustResponse.Content.ReadFromJsonAsync<TrustIdentifiers[]>();
         trustContent.Length.Should().Be(3);
-        AssertIdentifierResponse(trustContent.First(), selectedTrust);
-        AssertIdentifierResponse(trustContent[2], selectedTrust);
-        AssertIdentifierResponse(trustContent[3], selectedTrust);
+        AssertIdentifierResponse(trustContent.First(), trustData.First());
+        AssertIdentifierResponse(trustContent[1], trustData[1]);
+        AssertIdentifierResponse(trustContent[2], trustData[2]);
 
     }
     

--- a/TramsDataApi.Test/Integration/V4/IdentifiersV4IntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/V4/IdentifiersV4IntegrationTests.cs
@@ -137,7 +137,7 @@ public class IdentifiersV4IntegrationTests
     }
     
     [Fact]
-    public async Task Get_TrustIdentifiers_AndTrustDoesNotExist_Returns_NotFound()
+    public async Task Get_TrustIdentifiers_AndTrustDoesNotExist_Returns_EmptyList()
     {
         using var context = _apiFixture.GetMstrContext();
 
@@ -147,7 +147,9 @@ public class IdentifiersV4IntegrationTests
         await context.SaveChangesAsync();
 
         var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/noTrustExists");
-        trustResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        trustResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var trustContent = await trustResponse.Content.ReadFromJsonAsync<TrustIdentifiers[]>();
+        trustContent.Length.Should().Be(0);
     }
     
     private static List<Trust> BuildSmallTrustSet()

--- a/TramsDataApi.Test/Integration/V4/IdentifiersV4IntegrationTests.cs
+++ b/TramsDataApi.Test/Integration/V4/IdentifiersV4IntegrationTests.cs
@@ -5,9 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
-using AutoFixture;
 using Dfe.Academies.Application.Trust;
-using Dfe.Academies.Contracts.V4.Trusts;
 using Dfe.Academies.Domain.Trust;
 using FluentAssertions;
 using TramsDataApi.Test.Fixtures;
@@ -19,7 +17,6 @@ namespace TramsDataApi.Test.Integration.V4;
 public class IdentifiersV4IntegrationTests
 {
     private readonly HttpClient _client;
-    private static readonly Fixture _autoFixture = new Fixture();
     private readonly ApiTestFixture _apiFixture;
 
     private readonly string _apiUrlPrefix = "/v4";
@@ -30,8 +27,11 @@ public class IdentifiersV4IntegrationTests
         _client = fixture.Client;
     }
     
-    [Fact]
-    public async Task Get_TrustIdentifiersByUkPrn_AndTrustExists_Returns_Ok()
+    [Theory]
+    [InlineData(IdTypes.GroupID)]
+    [InlineData(IdTypes.UKPRN)]
+    [InlineData(IdTypes.GroupUID)]
+    public async Task Get_TrustIdentifiers_AndTrustExists_Returns_Ok(IdTypes idType)
     {
         using var context = _apiFixture.GetMstrContext();
 
@@ -42,7 +42,15 @@ public class IdentifiersV4IntegrationTests
 
         var selectedTrust = trustData.First();
 
-        var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/{selectedTrust.UKPRN}");
+        var identifier = idType switch
+        {
+            IdTypes.GroupID => selectedTrust.GroupID,
+            IdTypes.UKPRN => selectedTrust.UKPRN,
+            IdTypes.GroupUID => selectedTrust.GroupUID,
+            _ => throw new ArgumentOutOfRangeException(nameof(idType), idType, null)
+        };
+
+        var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/{identifier}");
         trustResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var trustContent = await trustResponse.Content.ReadFromJsonAsync<TrustIdentifiers[]>();
@@ -50,99 +58,30 @@ public class IdentifiersV4IntegrationTests
         AssertIdentifierResponse(trustContent.First(), selectedTrust);
     }
     
-    [Fact]
-    public async Task Get_TrustIdentifiersByUID_AndTrustExists_Returns_Ok()
+    [Theory]
+    [InlineData(IdTypes.GroupID)]
+    [InlineData(IdTypes.UKPRN)]
+    [InlineData(IdTypes.GroupUID)]
+    public async Task Get_TrustIdentifiers_AndDuplicateTrustsExists_Returns_Ok(IdTypes idType)
     {
         using var context = _apiFixture.GetMstrContext();
 
-        var trustData = BuildSmallTrustSet();
+        var trustData = BuildSmallDuplicateTrustSet(idType);
 
         context.Trusts.AddRange(trustData);
         context.SaveChanges();
 
         var selectedTrust = trustData.First();
+        
+        var identifier = idType switch
+        {
+            IdTypes.GroupID => "GroupID",
+            IdTypes.UKPRN => "UKPRN",
+            IdTypes.GroupUID => "GroupUID",
+            _ => throw new ArgumentOutOfRangeException(nameof(idType), idType, null)
+        };
 
-        var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/{selectedTrust.GroupUID}");
-        trustResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        var trustContent = await trustResponse.Content.ReadFromJsonAsync<TrustIdentifiers[]>();
-        trustContent.Length.Should().Be(1);
-        AssertIdentifierResponse(trustContent.First(), selectedTrust);
-    }
-    
-    [Fact]
-    public async Task Get_TrustIdentifiersByGroupID_AndTrustExists_Returns_Ok()
-    {
-        using var context = _apiFixture.GetMstrContext();
-
-        var trustData = BuildSmallTrustSet();
-
-        context.Trusts.AddRange(trustData);
-        context.SaveChanges();
-
-        var selectedTrust = trustData.First();
-
-        var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/{selectedTrust.GroupID}");
-        trustResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        var trustContent = await trustResponse.Content.ReadFromJsonAsync<TrustIdentifiers[]>();
-        trustContent.Length.Should().Be(1);
-        AssertIdentifierResponse(trustContent.First(), selectedTrust);
-    }
-    
-    [Fact]
-    public async Task Get_TrustIdentifiersByUKPRN_AndDuplicateTrustsExists_Returns_Ok()
-    {
-        using var context = _apiFixture.GetMstrContext();
-
-        var trustData = BuildSmallDuplicateTrustSet(IdTypes.UKPRN);
-
-        context.Trusts.AddRange(trustData);
-        context.SaveChanges();
-
-        var selectedTrust = trustData.First();
-
-        var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/UKPRN");
-        trustResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        var trustContent = await trustResponse.Content.ReadFromJsonAsync<TrustIdentifiers[]>();
-        trustContent.Length.Should().Be(3);
-        AssertIdentifierResponse(trustContent.First(), selectedTrust);
-    }
-    
-    [Fact]
-    public async Task Get_TrustIdentifiersByGroupUID_AndDuplicateTrustsExists_Returns_Ok()
-    {
-        using var context = _apiFixture.GetMstrContext();
-
-        var trustData = BuildSmallDuplicateTrustSet(IdTypes.GroupUID);
-
-        context.Trusts.AddRange(trustData);
-        context.SaveChanges();
-
-        var selectedTrust = trustData.First();
-
-        var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/GroupUID");
-        trustResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        var trustContent = await trustResponse.Content.ReadFromJsonAsync<TrustIdentifiers[]>();
-        trustContent.Length.Should().Be(3);
-        AssertIdentifierResponse(trustContent.First(), selectedTrust);
-    }
-    
-    [Fact]
-    public async Task Get_TrustIdentifiersByGroupID_AndDuplicateTrustsExists_Returns_Ok()
-    {
-        using var context = _apiFixture.GetMstrContext();
-
-        var trustData = BuildSmallDuplicateTrustSet(IdTypes.GroupID);
-
-        context.Trusts.AddRange(trustData);
-        context.SaveChanges();
-
-        var selectedTrust = trustData.First();
-
-        var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/GroupID");
+        var trustResponse = await _client.GetAsync($"{_apiUrlPrefix}/identifier/{identifier}");
         trustResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var trustContent = await trustResponse.Content.ReadFromJsonAsync<TrustIdentifiers[]>();
@@ -162,8 +101,8 @@ public class IdentifiersV4IntegrationTests
 
         return result;
     }
-    
-    private enum IdTypes { GroupID, UKPRN, GroupUID } 
+
+    public enum IdTypes { GroupID, UKPRN, GroupUID } 
     
     private static List<Trust> BuildSmallDuplicateTrustSet(IdTypes id)
     {
@@ -193,7 +132,7 @@ public class IdentifiersV4IntegrationTests
     
     private static void AssertIdentifierResponse(TrustIdentifiers actual, Trust expected)
     {
-        actual.TR.Should().Be(expected.GroupID);
+        actual.TrustReference.Should().Be(expected.GroupID);
         actual.UKPRN.Should().Be(expected.UKPRN);
         actual.UID.Should().Be(expected.GroupUID);
     }

--- a/TramsDataApi/Controllers/V4/IdentifiersController.cs
+++ b/TramsDataApi/Controllers/V4/IdentifiersController.cs
@@ -14,7 +14,7 @@ using TramsDataApi.ResponseModels;
 namespace TramsDataApi.Controllers.V4
 {
     /// <summary>
-    /// Handles operations related to Idenitfiers.
+    /// Handles operations related to Identifiers.
     /// </summary>
     [ApiController]
     [ApiVersion("4.0")]
@@ -32,9 +32,9 @@ namespace TramsDataApi.Controllers.V4
         }
 
         /// <summary>
-        /// Retrieves a Trust's Identifiers based on one of its identifiers.
+        /// Retrieves a Trust's other identifiers based on one of its identifiers. Currently supports UKPRN, UID and Trust Reference
         /// </summary>
-        /// <param name="identifier">The identifier (UKPRN, Group UID or Trust Reference).</param>
+        /// <param name="identifier">The identifier (UKPRN, UID or Trust Reference).</param>
         /// <param name="cancellationToken"></param>
         /// <returns>A Trust or NotFound if not available.</returns>
         [HttpGet]

--- a/TramsDataApi/Controllers/V4/IdentifiersController.cs
+++ b/TramsDataApi/Controllers/V4/IdentifiersController.cs
@@ -1,15 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Dfe.Academies.Application.Trust;
-using Dfe.Academies.Contracts.V4;
-using Dfe.Academies.Contracts.V4.Trusts;
-using Dfe.Academies.Domain.Trust;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
-using TramsDataApi.ResponseModels;
 
 namespace TramsDataApi.Controllers.V4
 {
@@ -44,17 +41,18 @@ namespace TramsDataApi.Controllers.V4
         [SwaggerResponse(404, "Trust with specified identifier not found.")]
         public async Task<ActionResult<TrustIdentifiers[]>> GetTrustIdentifiers(string identifier, CancellationToken cancellationToken)
         {
-            _logger.LogInformation($"Attempting to get trust identifiers by identifier {identifier}");
+            var loggableIdentifier = Regex.Replace(identifier, "[^a-zA-Z0-9-]", "", RegexOptions.None, TimeSpan.FromSeconds(2));
+            _logger.LogInformation("Attempting to get trust identifiers by identifier {identifier}", loggableIdentifier);
             var trusts = await _trustQueries.GetTrustIdentifiers(identifier, cancellationToken).ConfigureAwait(false);
             
             if (trusts == null)
             {
-                _logger.LogInformation($"No trust with identifier {identifier}");
+                _logger.LogInformation("No trust with identifier {identifier}", loggableIdentifier);
                 return NotFound();
             }
             
-            _logger.LogInformation($"Returning trusts found by identifier {identifier}");
-            _logger.LogDebug(JsonSerializer.Serialize(trusts));
+            _logger.LogInformation("Returning trusts found by identifier {identifier}", loggableIdentifier);
+            _logger.LogDebug("{output}",JsonSerializer.Serialize(trusts));
             return Ok(trusts.ToArray());
         }
     }

--- a/TramsDataApi/Controllers/V4/IdentifiersController.cs
+++ b/TramsDataApi/Controllers/V4/IdentifiersController.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Dfe.Academies.Application.Trust;
+using Dfe.Academies.Contracts.V4;
+using Dfe.Academies.Contracts.V4.Trusts;
+using Dfe.Academies.Domain.Trust;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Swashbuckle.AspNetCore.Annotations;
+using TramsDataApi.ResponseModels;
+
+namespace TramsDataApi.Controllers.V4
+{
+    /// <summary>
+    /// Handles operations related to Idenitfiers.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("4.0")]
+    [Route("v{version:apiVersion}/")]
+    [SwaggerTag("TrustIdentifiers Endpoints")]
+    public class IdentifiersController : ControllerBase
+    {
+        private readonly ITrustQueries _trustQueries;
+        private readonly ILogger<TrustsController> _logger;
+
+        public IdentifiersController(ITrustQueries trustQueries, ILogger<TrustsController> logger)
+        {
+            _trustQueries = trustQueries;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Retrieves a Trust's Identifiers based on one of its identifiers.
+        /// </summary>
+        /// <param name="identifier">The identifier (UKPRN, Group UID or Trust Reference).</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>A Trust or NotFound if not available.</returns>
+        [HttpGet]
+        [Route("identifier/{identifier}")]        
+        [SwaggerOperation(Summary = "Retrieves a Trust's Identifiers based on one of its identifiers.", Description = "Returns a Trust identifiers found in the database.")]
+        [SwaggerResponse(200, "Successfully found and returned the Trusts identifiers.")]
+        [SwaggerResponse(404, "Trust with specified identifier not found.")]
+        public async Task<ActionResult<TrustDto>> GetTrustIdentifiers(string identifier, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation($"Attempting to get trust identifiers by identifier {identifier}");
+            var trusts = await _trustQueries.GetTrustIdentifiers(identifier, cancellationToken).ConfigureAwait(false);
+            
+            if (trusts == null)
+            {
+                _logger.LogInformation($"No trust with identifier {identifier}");
+                return NotFound();
+            }
+            
+            _logger.LogInformation($"Returning trusts found by identifier {identifier}");
+            _logger.LogDebug(JsonSerializer.Serialize(trusts));
+            return Ok(trusts);
+        }
+    }
+}

--- a/TramsDataApi/Controllers/V4/IdentifiersController.cs
+++ b/TramsDataApi/Controllers/V4/IdentifiersController.cs
@@ -8,52 +8,51 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Swashbuckle.AspNetCore.Annotations;
 
-namespace TramsDataApi.Controllers.V4
+namespace TramsDataApi.Controllers.V4;
+
+/// <summary>
+/// Handles operations related to Identifiers.
+/// </summary>
+[ApiController]
+[ApiVersion("4.0")]
+[Route("v{version:apiVersion}/")]
+[SwaggerTag("TrustIdentifiers Endpoints")]
+public class IdentifiersController : ControllerBase
 {
-    /// <summary>
-    /// Handles operations related to Identifiers.
-    /// </summary>
-    [ApiController]
-    [ApiVersion("4.0")]
-    [Route("v{version:apiVersion}/")]
-    [SwaggerTag("TrustIdentifiers Endpoints")]
-    public class IdentifiersController : ControllerBase
+    private readonly ITrustQueries _trustQueries;
+    private readonly ILogger<TrustsController> _logger;
+
+    public IdentifiersController(ITrustQueries trustQueries, ILogger<TrustsController> logger)
     {
-        private readonly ITrustQueries _trustQueries;
-        private readonly ILogger<TrustsController> _logger;
+        _trustQueries = trustQueries;
+        _logger = logger;
+    }
 
-        public IdentifiersController(ITrustQueries trustQueries, ILogger<TrustsController> logger)
-        {
-            _trustQueries = trustQueries;
-            _logger = logger;
-        }
-
-        /// <summary>
-        /// Retrieves a Trust's other identifiers based on one of its identifiers. Currently supports UKPRN, UID and Trust Reference
-        /// </summary>
-        /// <param name="identifier">The identifier (UKPRN, UID or Trust Reference).</param>
-        /// <param name="cancellationToken"></param>
-        /// <returns>A Trust or NotFound if not available.</returns>
-        [HttpGet]
-        [Route("identifier/{identifier}")]        
-        [SwaggerOperation(Summary = "Retrieves a Trust's Identifiers based on one of its identifiers.", Description = "Returns a Trust identifiers found in the database.")]
-        [SwaggerResponse(200, "Successfully found and returned the Trusts identifiers.")]
-        [SwaggerResponse(404, "Trust with specified identifier not found.")]
-        public async Task<ActionResult<TrustIdentifiers[]>> GetTrustIdentifiers(string identifier, CancellationToken cancellationToken)
-        {
-            var loggableIdentifier = Regex.Replace(identifier, "[^a-zA-Z0-9-]", "", RegexOptions.None, TimeSpan.FromSeconds(2));
-            _logger.LogInformation("Attempting to get trust identifiers by identifier {identifier}", loggableIdentifier);
-            var trusts = await _trustQueries.GetTrustIdentifiers(identifier, cancellationToken).ConfigureAwait(false);
+    /// <summary>
+    /// Retrieves a Trust's other identifiers based on one of its identifiers. Currently supports UKPRN, UID and Trust Reference
+    /// </summary>
+    /// <param name="identifier">The identifier (UKPRN, UID or Trust Reference).</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>A Trust or NotFound if not available.</returns>
+    [HttpGet]
+    [Route("identifier/{identifier}")]        
+    [SwaggerOperation(Summary = "Retrieves a Trust's Identifiers based on one of its identifiers.", Description = "Returns a Trust identifiers found in the database.")]
+    [SwaggerResponse(200, "Successfully found and returned the Trusts identifiers.")]
+    [SwaggerResponse(404, "Trust with specified identifier not found.")]
+    public async Task<ActionResult<TrustIdentifiers[]>> GetTrustIdentifiers(string identifier, CancellationToken cancellationToken)
+    {
+        var loggableIdentifier = Regex.Replace(identifier, "[^a-zA-Z0-9-]", "", RegexOptions.None, TimeSpan.FromSeconds(2));
+        _logger.LogInformation("Attempting to get trust identifiers by identifier {identifier}", loggableIdentifier);
+        var trusts = await _trustQueries.GetTrustIdentifiers(identifier, cancellationToken).ConfigureAwait(false);
             
-            if (trusts == null)
-            {
-                _logger.LogInformation("No trust with identifier {identifier}", loggableIdentifier);
-                return NotFound();
-            }
-            
-            _logger.LogInformation("Returning trusts found by identifier {identifier}", loggableIdentifier);
-            _logger.LogDebug("{output}",JsonSerializer.Serialize(trusts));
-            return Ok(trusts.ToArray());
+        if (trusts == null)
+        {
+            _logger.LogInformation("No trust with identifier {identifier}", loggableIdentifier);
+            return NotFound();
         }
+            
+        _logger.LogInformation("Returning trusts found by identifier {identifier}", loggableIdentifier);
+        _logger.LogDebug("{output}",JsonSerializer.Serialize(trusts));
+        return Ok(trusts.ToArray());
     }
 }

--- a/TramsDataApi/Controllers/V4/IdentifiersController.cs
+++ b/TramsDataApi/Controllers/V4/IdentifiersController.cs
@@ -42,7 +42,7 @@ namespace TramsDataApi.Controllers.V4
         [SwaggerOperation(Summary = "Retrieves a Trust's Identifiers based on one of its identifiers.", Description = "Returns a Trust identifiers found in the database.")]
         [SwaggerResponse(200, "Successfully found and returned the Trusts identifiers.")]
         [SwaggerResponse(404, "Trust with specified identifier not found.")]
-        public async Task<ActionResult<TrustDto>> GetTrustIdentifiers(string identifier, CancellationToken cancellationToken)
+        public async Task<ActionResult<TrustIdentifiers[]>> GetTrustIdentifiers(string identifier, CancellationToken cancellationToken)
         {
             _logger.LogInformation($"Attempting to get trust identifiers by identifier {identifier}");
             var trusts = await _trustQueries.GetTrustIdentifiers(identifier, cancellationToken).ConfigureAwait(false);
@@ -55,7 +55,7 @@ namespace TramsDataApi.Controllers.V4
             
             _logger.LogInformation($"Returning trusts found by identifier {identifier}");
             _logger.LogDebug(JsonSerializer.Serialize(trusts));
-            return Ok(trusts);
+            return Ok(trusts.ToArray());
         }
     }
 }

--- a/TramsDataApi/Controllers/V4/IdentifiersController.cs
+++ b/TramsDataApi/Controllers/V4/IdentifiersController.cs
@@ -45,7 +45,7 @@ public class IdentifiersController : ControllerBase
         _logger.LogInformation("Attempting to get trust identifiers by identifier {identifier}", loggableIdentifier);
         var trusts = await _trustQueries.GetTrustIdentifiers(identifier, cancellationToken).ConfigureAwait(false);
             
-        if (trusts == null)
+        if (trusts.Count <= 0)
         {
             _logger.LogInformation("No trust with identifier {identifier}", loggableIdentifier);
             return NotFound();

--- a/TramsDataApi/Controllers/V4/IdentifiersController.cs
+++ b/TramsDataApi/Controllers/V4/IdentifiersController.cs
@@ -45,12 +45,6 @@ public class IdentifiersController : ControllerBase
         _logger.LogInformation("Attempting to get trust identifiers by identifier {identifier}", loggableIdentifier);
         var trusts = await _trustQueries.GetTrustIdentifiers(identifier, cancellationToken).ConfigureAwait(false);
             
-        if (trusts.Count <= 0)
-        {
-            _logger.LogInformation("No trust with identifier {identifier}", loggableIdentifier);
-            return NotFound();
-        }
-            
         _logger.LogInformation("Returning trusts found by identifier {identifier}", loggableIdentifier);
         _logger.LogDebug("{output}",JsonSerializer.Serialize(trusts));
         return Ok(trusts.ToArray());


### PR DESCRIPTION
Adds an initial version of the Identifier endpoint to the Academies API. This allows you to search by a trust UKPRN, UID or Trust Reference and the other identifiers found for that are returned.

Includes integration tests for the endpoint as well.