### PR TITLE
Add exclusion paths for build and test

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -4,9 +4,19 @@ on:
   push:
     branches:
     - main
+    paths:
+    - 'Dfe.Academies.*'
+    - 'TramsDataApi*'
+    - '!Dfe.Academies.Performance'
+    - '!*.csproj'
   pull_request:
     branches: [ main ]
     types: [ opened, synchronize, reopened ]
+    paths:
+    - 'Dfe.Academies.*'
+    - 'TramsDataApi*'
+    - '!Dfe.Academies.Performance'
+    - '!*.csproj'
 
 env:
   DOTNET_VERSION: '6.0.403'


### PR DESCRIPTION
Sets paths to restrict when to run build and test.

This is to reduce the amount of times that sonarcloud is ran and to free up github runners