### PR TITLE
Aspnet 8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS final
 
 RUN apt-get update
 RUN apt-get install unixodbc curl gnupg -y
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
 RUN curl https://packages.microsoft.com/config/debian/12/prod.list | tee /etc/apt/sources.list.d/msprod.list
 RUN apt-get update
 RUN ACCEPT_EULA=Y apt-get install msodbcsql18 mssql-tools18 -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,6 @@ COPY --from=build /app /app
 WORKDIR /app
 COPY ./script/web-docker-entrypoint.sh ./docker-entrypoint.sh
 RUN chmod +x ./docker-entrypoint.sh
+
+ENV ASPNETCORE_HTTP_PORTS 80
 EXPOSE 80/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN touch /app/SQL/DbMigrationScript.sql
 RUN --mount=type=secret,id=github_token dotnet nuget add source --username USERNAME --password $(cat /run/secrets/github_token) --store-password-in-clear-text --name github "https://nuget.pkg.github.com/DFE-Digital/index.json"
 RUN dotnet restore TramsDataApi.sln
 RUN dotnet new tool-manifest
-RUN dotnet tool install dotnet-ef --version 6.0.5
+RUN dotnet tool install dotnet-ef --version 8.0.7
 ENV PATH="$PATH:/root/.dotnet/tools"
 
 RUN dotnet ef migrations script --output /app/SQL/DbMigrationScriptLegacy.sql --project TramsDataApi --context TramsDataApi.DatabaseModels.LegacyTramsDbContext --idempotent -v
@@ -23,12 +23,12 @@ RUN dotnet build -c Release TramsDataApi.sln --no-restore
 RUN dotnet publish TramsDataApi -c Release -o /app --no-restore
 
 ARG ASPNET_IMAGE_TAG
-FROM mcr.microsoft.com/dotnet/aspnet:7.0.20-bullseye-slim AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS final
 
 RUN apt-get update
 RUN apt-get install unixodbc curl gnupg -y
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-RUN curl https://packages.microsoft.com/config/debian/11/prod.list | tee /etc/apt/sources.list.d/msprod.list
+RUN curl https://packages.microsoft.com/config/debian/12/prod.list | tee /etc/apt/sources.list.d/msprod.list
 RUN apt-get update
 RUN ACCEPT_EULA=Y apt-get install msodbcsql18 mssql-tools18 -y
 


### PR DESCRIPTION
When the 8.0 monorepo was merged, the SDK was bumped to 8.0 but the runtime was left on 7 which meant the container could not boot because it did not have the correct version.

The jump to 8 also means the base image now sets 8080 as the default so an ENV was added to set back to 80 which should mean the least impact to the container app environment

<img width="431" alt="Screenshot 2024-07-22 at 14 56 26" src="https://github.com/user-attachments/assets/7671d099-3929-452e-a275-62740dcb29ed">
