### PR TITLE
Add tag prefix when building multiple images

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -58,13 +58,16 @@ jobs:
           include:
             - image: "Dockerfile"
               aca_name_secret: "AZURE_ACA_NAME"
+              prefix: ""
               name: "tramsapi-app"
             - image: "Dockerfile.PersonsApi"
               aca_name_secret: "AZURE_PERSONS_API_ACA_NAME"
+              prefix: "persons-api-"
               name: "personsapi-app"
     with:
       docker-image-name: '${{ matrix.name }}'
       docker-build-file-name: './${{ matrix.image }}'
+      docker-tag-prefix: ${{ matrix.prefix }}
       environment: ${{ needs.set-env.outputs.environment }}
       # Only annotate the release once, because both apps are deployed at the same time
       annotate-release: ${{ matrix.name == 'tramsapi-app' }}


### PR DESCRIPTION
- Prefix image tags when built on GHCR so that persons api is distinct from academies api, otherwise we will have 2x academies-api packages published which are different projects