### PR TITLE
Fix docker image scan workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Build docker image
         uses: docker/build-push-action@v6
         with:
+          build-args: CI=true
           file: './${{ matrix.image }}'
           secrets: github_token=${{ secrets.GITHUB_TOKEN }}
           cache-from: type=gha


### PR DESCRIPTION
The docker images won't build properly without this flag. 