### PR TITLE
Fix docker image scanner workflow

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -27,6 +27,7 @@ jobs:
         id: build
         with:
           file: './${{ matrix.image }}'
+          build-args: CI=true
           secrets: github_token=${{ secrets.GITHUB_TOKEN }}
           load: true
           cache-from: type=gha


### PR DESCRIPTION
In https://github.com/DFE-Digital/academies-api/pull/592 I added the build flag to the docker build workflow, but forgot to add it to the scanner task 🙃 