### PR TITLE
Use Azure Linux base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,47 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build
+# Set the major version of dotnet
+ARG DOTNET_VERSION=8.0
+
+# Build the app using the dotnet SDK
+FROM "mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}-azurelinux3.0" AS build
 WORKDIR /build
-
-ENV DEBIAN_FRONTEND=noninteractive
-
 ARG CI
 ENV CI=${CI}
 
 COPY . .
+COPY ./script/web-docker-entrypoint.sh /app/docker-entrypoint.sh
 
-RUN mkdir -p /app/SQL
-RUN touch /app/SQL/DbMigrationScriptLegacy.sql
-RUN touch /app/SQL/DbMigrationScript.sql
-
+# Mount GitHub Token as a Docker secret so that NuGet Feed can be accessed
 RUN --mount=type=secret,id=github_token dotnet nuget add source --username USERNAME --password $(cat /run/secrets/github_token) --store-password-in-clear-text --name github "https://nuget.pkg.github.com/DFE-Digital/index.json"
-RUN dotnet restore TramsDataApi.sln
-RUN dotnet new tool-manifest
-RUN dotnet tool install dotnet-ef --version 8.0.8
-ENV PATH="$PATH:/root/.dotnet/tools"
 
-RUN dotnet ef migrations script --output /app/SQL/DbMigrationScriptLegacy.sql --project TramsDataApi --context TramsDataApi.DatabaseModels.LegacyTramsDbContext --idempotent -v
-RUN dotnet ef migrations script --output /app/SQL/DbMigrationScript.sql --project TramsDataApi --context TramsDataApi.DatabaseModels.TramsDbContext --idempotent --no-build -v
+# Generate the Entity Framework migration scripts
+RUN ["dotnet", "new", "tool-manifest"]
+RUN ["dotnet", "tool", "install", "dotnet-ef", "--version", "8.0.11"]
+RUN ["mkdir", "-p", "/app/SQL"]
+RUN ["touch", "/app/SQL/DbMigrationScriptOutput.txt"]
+RUN ["touch", "/app/SQL/DbMigrationScriptOutputLegacy.txt"]
+RUN ["dotnet", "restore", "TramsDataApi.sln"]
+RUN ["dotnet", "ef", "migrations", "script", "--output", "/app/SQL/DbMigrationScriptLegacy.sql", "--project", "TramsDataApi", "--context", "TramsDataApi.DatabaseModels.LegacyTramsDbContext", "--idempotent"]
+RUN ["dotnet", "ef", "migrations", "script", "--output", "/app/SQL/DbMigrationScript.sql", "--project", "TramsDataApi", "--context", "TramsDataApi.DatabaseModels.TramsDbContext", "--idempotent"]
 
-# this build has no effect on ef migrations because it is a "Release" configuration
-RUN dotnet build -c Release TramsDataApi.sln --no-restore -p:CI=${CI}
-RUN dotnet publish TramsDataApi -c Release -o /app --no-restore
+# Build and publish the dotnet solution
+RUN dotnet build TramsDataApi.sln --no-restore -c Release -p CI=${CI}
+RUN ["dotnet", "publish", "TramsDataApi", "--no-build", "-o", "/app"]
 
-ARG ASPNET_IMAGE_TAG
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS final
+# Install SQL tools to allow migrations to be run
+FROM "mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-azurelinux3.0" AS base
+RUN curl "https://packages.microsoft.com/config/rhel/9/prod.repo" | tee /etc/yum.repos.d/mssql-release.repo
+ENV ACCEPT_EULA=Y
+RUN ["tdnf", "update"]
+RUN ["tdnf", "install", "-y", "mssql-tools18"]
+RUN ["tdnf", "clean", "all"]
 
-RUN apt-get update
-RUN apt-get install unixodbc curl gnupg -y
-RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
-RUN curl https://packages.microsoft.com/config/debian/12/prod.list | tee /etc/apt/sources.list.d/msprod.list
-RUN apt-get update
-RUN ACCEPT_EULA=Y apt-get install msodbcsql18 mssql-tools18 -y
+# Build a runtime environment
+FROM base AS final
+WORKDIR /app
+LABEL org.opencontainers.image.source="https://github.com/DFE-Digital/academies-api"
+LABEL org.opencontainers.image.description="Academies API"
 
 COPY --from=build /app /app
-
-WORKDIR /app
-COPY ./script/web-docker-entrypoint.sh ./docker-entrypoint.sh
-RUN chmod +x ./docker-entrypoint.sh
-
-ENV ASPNETCORE_HTTP_PORTS 80
-EXPOSE 80/tcp
+RUN ["chmod", "+x", "./docker-entrypoint.sh"]
+RUN chown "$APP_UID" "/app/SQL" -R
+USER $APP_UID

--- a/Dockerfile.PersonsApi
+++ b/Dockerfile.PersonsApi
@@ -1,36 +1,28 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build
+# Set the major version of dotnet
+ARG DOTNET_VERSION=8.0
+
+# Build the app using the dotnet SDK
+FROM "mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}-azurelinux3.0" AS build
 WORKDIR /build
-
-ENV DEBIAN_FRONTEND=noninteractive
-
 ARG CI
 ENV CI=${CI}
 
 COPY . .
+COPY ./script/personsapi.docker-entrypoint.sh /app/docker-entrypoint.sh
 
 RUN --mount=type=secret,id=github_token dotnet nuget add source --username USERNAME --password $(cat /run/secrets/github_token) --store-password-in-clear-text --name github "https://nuget.pkg.github.com/DFE-Digital/index.json"
-RUN dotnet build -c Release PersonsApi -p:CI=${CI}
-RUN dotnet publish PersonsApi -c Release -o /app --no-restore
 
-RUN dotnet new tool-manifest
-RUN dotnet tool install dotnet-ef --version 8.0.8
-ENV PATH="$PATH:/root/.dotnet/tools"
+# Restore, build and publish the dotnet solution
+RUN ["dotnet", "restore", "PersonsApi"]
+RUN dotnet build PersonsApi --no-restore -c Release -p CI=${CI}
+RUN ["dotnet", "publish", "PersonsApi", "--no-build", "-o", "/app"]
 
-ARG ASPNET_IMAGE_TAG
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS final
-
-RUN apt-get update
-RUN apt-get install unixodbc curl gnupg -y
-RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
-RUN curl https://packages.microsoft.com/config/debian/12/prod.list | tee /etc/apt/sources.list.d/msprod.list
-RUN apt-get update
-RUN ACCEPT_EULA=Y apt-get install msodbcsql18 mssql-tools18 -y
+# Build a runtime environment
+FROM "mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-azurelinux3.0" AS final
+WORKDIR /app
+LABEL org.opencontainers.image.source="https://github.com/DFE-Digital/academies-api"
+LABEL org.opencontainers.image.description="Persons API"
 
 COPY --from=build /app /app
-
-WORKDIR /app
-COPY ./script/personsapi.docker-entrypoint.sh ./docker-entrypoint.sh
-RUN chmod +x ./docker-entrypoint.sh
-
-ENV ASPNETCORE_HTTP_PORTS 80
-EXPOSE 80/tcp
+RUN ["chmod", "+x", "./docker-entrypoint.sh"]
+USER $APP_UID


### PR DESCRIPTION
* Reduces the overall final image size by using Azure Linux
* Offers maximum compatibility with Azure infrastructure
* Uses arbitrary user instead of 'root'
* Supported by Microsoft

https://github.com/dotnet/dotnet-docker/blob/main/documentation/azurelinux.md#azure-linux

>[!WARNING]
>Note: ASP.NET Core apps (in official images) listen to [port 8080 by default⁠](https://github.com/dotnet/dotnet-docker/blob/6da64f31944bb16ecde5495b6a53fc170fbe100d/src/runtime-deps/8.0/bookworm-slim/amd64/Dockerfile#L7), starting with .NET 8. This is because it is using an arbitrary user. As a result we will need to update the Container App definition to list to Port 8080
