### PR TITLE
Adjust expected response from HealthCheck test

### DIFF
--- a/CypressTests/cypress/e2e/v1/healthchecks.cy.js
+++ b/CypressTests/cypress/e2e/v1/healthchecks.cy.js
@@ -12,26 +12,9 @@ describe("Health and Database Checks", () => {
         }
       })
         .then((response) => {
-          expect(response.body).to.contain('Health check ok')
+          expect(response.body).to.contain('Healthy')
           expect(response.status).to.eq(200)
         })
     })
   })
-
-  context('Database check endpoint', () => {
-    it('should return a healthy response', () => {
-      cy.api({
-        url: `${url}/check_db`,
-        headers: {
-          ApiKey: apiKey,
-          "Content-type": "application/json"
-        }
-      })
-        .then((response) => {
-          expect(response.status).to.eq(200)
-          expect(response.body).to.eq(true)
-        })
-    })
-  })
-
 })


### PR DESCRIPTION
In https://github.com/DFE-Digital/academies-api/pull/648 we adjusted how health checks work, so that rather than being a registered API Endpoint, it is using the default .NET method, which now also includes a check of the database connection.

The URL is still /HealthCheck but the response body has changed so the cypress test should reflect that.

The /check_db no longer exists as it is part of the /HealthCheck system now.