### PR TITLE
Switch to using Cypress docker image for running tests

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -1,4 +1,4 @@
-name: Run Cypress tests
+name: Cypress Tests using Cypress Docker Image
 
 on:
   workflow_call:
@@ -21,14 +21,18 @@ on:
 concurrency:
   group: ${{ github.workflow }}
 
-env:
-  NODE_VERSION: 18.x
-
 jobs:
   cypress-tests:
     name: Run Cypress Tests
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    strategy:
+      matrix:
+        browser: [
+          "edge"
+        ]
+    container:
+      image: cypress/browsers:22.12.0
     defaults:
       run:
         working-directory: CypressTests/
@@ -37,21 +41,18 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Setup node.js
-        uses: actions/setup-node@v4
+      - name: Run
+        uses: cypress-io/github-action@v6
+        env:
+          CYPRESS_apiKey: ${{ secrets.TRAMS_API_KEY }}
+          CYPRESS_url: ${{ secrets.TRAMS_API_BASE_URL }}
         with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Npm install
-        run: npm install
-
-      - name: Run Cypress (${{ inputs.environment }})
-        if: inputs.environment == 'test' || inputs.environment == 'development'
-        run: npm run cy:run -- --env apiKey="${{ secrets.TRAMS_API_KEY }}",url="${{ secrets.TRAMS_API_BASE_URL }}"
+          browser: ${{ matrix.browser }}
+          working-directory: CypressTests
 
       - name: Upload screenshots
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: screenshots-${{ needs.set-env.outputs.environment }}
+          name: screenshots-${{ inputs.environment }}-${{ matrix.browser }}
           path: screenshots


### PR DESCRIPTION
- This will ensure the browser versions remain static
- We will also use the Cypress action to run the tests for maximum caching and compatibility

Last run: https://github.com/DFE-Digital/academies-api/actions/runs/12355887527