### PR TITLE
Fixed "Data is null" exception when NumberOfShortInspectionsSinceLast…

### DIFF
--- a/Dfe.Academies.Domain/Establishment/FurtherEducationEstablishment.cs
+++ b/Dfe.Academies.Domain/Establishment/FurtherEducationEstablishment.cs
@@ -11,7 +11,7 @@ public class FurtherEducationEstablishment
     public string? Region { get; set; }
     public string? OfstedRegion { get; set; }
     public string? DateOfLatestShortInspection { get; set; }
-    public int NumberOfShortInspectionsSinceLastFullInspection { get; set; }
+    public int? NumberOfShortInspectionsSinceLastFullInspection { get; set; }
     public string? InspectionNumber { get; set; }
     public string? InspectionType { get; set; }
     public string? FirstDayOfInspection { get; set; }


### PR DESCRIPTION
Fixed "Data is null" exception when NumberOfShortInspectionsSinceLastFullInspection is null in the database but it is set as not null in the EF entity