### PR TITLE
Split workflow into concurrent build and import stages

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -14,89 +14,104 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.environment }}
 
+env:
+  IMAGE_NAME: tramsapi-app
+
 jobs:
   set-env:
     name: Determine environment
     runs-on: ubuntu-24.04
     outputs:
       environment: ${{ steps.var.outputs.environment }}
-      branch: ${{ steps.var.outputs.branch }}
       release: ${{ steps.var.outputs.release }}
-      checked-out-sha: ${{ steps.var.outputs.checked-out-sha }}
+      image-name: ${{ steps.var.outputs.image-name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Get branch name for push/dispatch event
-        run: |
-          GIT_REF=${{ github.ref_name }}
-          echo "branch_ref=${GIT_REF}" >> $GITHUB_ENV
-
       - id: var
         run: |
-          GIT_REF=${{ env.branch_ref }}
-          GIT_BRANCH=${GIT_REF##*/}
           INPUT=${{ github.event.inputs.environment }}
           ENVIRONMENT=${INPUT:-"development"}
-          CHECKED_OUT_SHA="$(git log -1 '--format=format:%H')"
           RELEASE=${ENVIRONMENT,,}-`date +%Y-%m-%d`.${{ github.run_number }}
           echo "environment=${ENVIRONMENT,,}" >> $GITHUB_OUTPUT
-          echo "branch=$GIT_BRANCH" >> $GITHUB_OUTPUT
-          echo "checked-out-sha=${CHECKED_OUT_SHA}" >> $GITHUB_OUTPUT
           echo "release=${RELEASE}" >> $GITHUB_OUTPUT
+          echo "image-name=${{ env.IMAGE_NAME }}" >> $GITHUB_OUTPUT
 
-  build-import-init-container:
-    permissions:
-      id-token: write
-      contents: read
-      packages: write
-    name: Build and import Init Container
+  build:
+    name: Build
     needs: [ set-env ]
-    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@v3.1.0
+    permissions:
+      packages: write
+    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build.yml@v4.1.0
+    strategy:
+      matrix:
+        stage: [
+          "final",
+          "initcontainer"
+        ]
+        include:
+          - stage: "final"
+            tag-prefix: ""
+          - stage: "initcontainer"
+            tag-prefix: "init-"
     with:
-      docker-image-name: tramsapi-app
-      docker-build-target: initcontainer
-      docker-tag-prefix: init-
       environment: ${{ needs.set-env.outputs.environment }}
-      import-without-deploy: true
+      docker-image-name: ${{ needs.set-env.outputs.image-name }}
+      docker-build-file-name: ${{ inputs.docker-build-file-name }}
+      docker-build-context: ${{ inputs.docker-build-context }}
       docker-build-args: CI=true
-    secrets:
-      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      azure-acr-client-id: ${{ secrets.ACR_CLIENT_ID }}
-      azure-acr-name: ${{ secrets.ACR_NAME }}
-      azure-aca-client-id: ${{ secrets.ACA_CLIENT_ID }}
-      azure-aca-name: ${{ secrets.ACA_CONTAINERAPP_NAME }}
-      azure-aca-resource-group: ${{ secrets.ACA_RESOURCE_GROUP }}
+      docker-build-target: ${{ matrix.stage }}
+      docker-tag-prefix: ${{ matrix.tag-prefix }}
 
-  build-import-deploy-app:
+  import:
+    name: Import
+    needs: [ set-env, build ]
     permissions:
       id-token: write
-      contents: read
-      packages: write
-    name: Build, import and deploy App Container
-    needs: [ build-import-init-container ]
-    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@v3.1.0
+    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/import.yml@v4.1.0
+    strategy:
+      matrix:
+        stage: [
+          "final",
+          "initcontainer"
+        ]
+        include:
+          - stage: "final"
+            tag-prefix: ""
+          - stage: "initcontainer"
+            tag-prefix: "init-"
     with:
-      docker-image-name: tramsapi-app
-      docker-build-target: final
       environment: ${{ needs.set-env.outputs.environment }}
-      annotate-release: true
-      docker-build-args: |
-        COMMIT_SHA="${{ needs.set-env.outputs.checked-out-sha }}"
-        CI=true
+      docker-image-name: ${{ needs.set-env.outputs.image-name }}
+      docker-tag-prefix: ${{ matrix.tag-prefix }}
     secrets:
       azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
       azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       azure-acr-client-id: ${{ secrets.ACR_CLIENT_ID }}
       azure-acr-name: ${{ secrets.ACR_NAME }}
+
+  deploy:
+    name: Deploy
+    needs: [ set-env, import ]
+    permissions:
+      id-token: write
+    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/deploy.yml@v4.1.0
+    with:
+      environment: ${{ needs.set-env.outputs.environment }}
+      docker-image-name: ${{ needs.set-env.outputs.image-name }}
+      annotate-release: true
+    secrets:
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       azure-aca-client-id: ${{ secrets.ACA_CLIENT_ID }}
       azure-aca-name: ${{ secrets.ACA_CONTAINERAPP_NAME }}
       azure-aca-resource-group: ${{ secrets.ACA_RESOURCE_GROUP }}
+      azure-acr-name: ${{ secrets.ACR_NAME }}
 
   create-tag:
     name: Tag and release
-    needs: [ set-env, build-import-deploy-app ]
+    needs: [ set-env, deploy ]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -147,7 +162,7 @@ jobs:
 
   cypress-tests:
     name: Run Cypress Tests
-    needs: [ set-env, create-tag ]
+    needs: [ set-env, deploy ]
     if: needs.set-env.outputs.environment == 'test' || needs.set-env.outputs.environment == 'development'
     uses: ./.github/workflows/cypress-tests.yml
     with:


### PR DESCRIPTION
* This makes it easier for us to manage the individual docker stages for both the main api and the init container