### PR TITLE
Added excludeClosed parameter to v4 search for establishments

### DIFF
--- a/Dfe.Academies.Application/Establishment/EstablishmentQueries.cs
+++ b/Dfe.Academies.Application/Establishment/EstablishmentQueries.cs
@@ -40,9 +40,9 @@ namespace Dfe.Academies.Application.Establishment
             return MapToEstablishmentDto(establishment);
         }
 
-        public async Task<(List<EstablishmentDto>, int)> Search(string name, string ukPrn, string urn, CancellationToken cancellationToken)
+        public async Task<(List<EstablishmentDto>, int)> Search(string name, string ukPrn, string urn, bool? excludeClosed, CancellationToken cancellationToken)
         {
-            var establishments = await _establishmentRepository.Search(name, ukPrn, urn, cancellationToken);
+            var establishments = await _establishmentRepository.Search(name, ukPrn, urn, excludeClosed, cancellationToken);
 
             return (establishments.Select(x => MapToEstablishmentDto(x)).ToList(), establishments.Count);
         }

--- a/Dfe.Academies.Application/Establishment/IEstablishmentQueries.cs
+++ b/Dfe.Academies.Application/Establishment/IEstablishmentQueries.cs
@@ -6,7 +6,7 @@ namespace Dfe.Academies.Application.Establishment
     {
         Task<EstablishmentDto?> GetByUkprn(string ukprn, CancellationToken cancellationToken);
         Task<EstablishmentDto?> GetByUrn(string urn, CancellationToken cancellationToken);
-        Task<(List<EstablishmentDto>, int)> Search(string name, string ukPrn, string urn, CancellationToken cancellationToken);
+        Task<(List<EstablishmentDto>, int)> Search(string name, string ukPrn, string urn, bool? excludeClosed, CancellationToken cancellationToken);
         Task<IEnumerable<int>> GetURNsByRegion(string[] regions, CancellationToken cancellationToken);
         Task<List<EstablishmentDto>> GetByUrns(int[] Urns, CancellationToken cancellationToken);
         Task<List<EstablishmentDto>> GetByUkprns(string[] Ukprns, CancellationToken cancellationToken);

--- a/Dfe.Academies.Domain/Interfaces/Repositories/IEstablishmentRepository.cs
+++ b/Dfe.Academies.Domain/Interfaces/Repositories/IEstablishmentRepository.cs
@@ -5,9 +5,9 @@
         Task<Domain.Establishment.Establishment?> GetEstablishmentByUkprn(string ukprn, CancellationToken cancellationToken);
         Task<Domain.Establishment.Establishment?> GetEstablishmentByUrn(string urn, CancellationToken cancellationToken);
         Task<List<Domain.Establishment.Establishment>> Search(string name, string ukPrn,
-         string urn, CancellationToken cancellationToken);
-        Task<IEnumerable<int>> GetURNsByRegion(string[] regions, CancellationToken cancellationToken);        
-        Task<List<Domain.Establishment.Establishment>> GetByTrust(long? trustId, CancellationToken cancellationToken);        
+         string urn, bool? excludeClosed, CancellationToken cancellationToken);
+        Task<IEnumerable<int>> GetURNsByRegion(string[] regions, CancellationToken cancellationToken);
+        Task<List<Domain.Establishment.Establishment>> GetByTrust(long? trustId, CancellationToken cancellationToken);
         Task<List<Domain.Establishment.Establishment>> GetByUrns(int[] Urns, CancellationToken cancellationToken);
         Task<List<Domain.Establishment.Establishment>> GetByUkprns(string[] Urns, CancellationToken cancellationToken);
     }

--- a/Dfe.Academies.TramsDataApi.Tests.Integration/Controllers/V4/EstablishmentsControllerTests.cs
+++ b/Dfe.Academies.TramsDataApi.Tests.Integration/Controllers/V4/EstablishmentsControllerTests.cs
@@ -1,0 +1,68 @@
+using Dfe.Academies.Tests.Common.Customizations;
+using Dfe.AcademiesApi.Client.Contracts;
+using DfE.CoreLibs.Testing.AutoFixture.Attributes;
+using DfE.CoreLibs.Testing.Mocks.WebApplicationFactory;
+using TramsDataApi;
+
+namespace Dfe.Academies.TramsDataApi.Tests.Integration.Controllers.V4;
+
+public class EstablishmentsControllerTests
+{
+
+    [Theory]
+    [CustomAutoData(typeof(CustomWebApplicationDbContextFactoryCustomization<Startup>))]
+    public async Task SearchEstablishmentsAsync_ShouldReturnAllEstablishments_WhenClosedDateIsNull(
+        CustomWebApplicationDbContextFactory<Startup> factory,
+        IEstablishmentsV4Client establishmentsClient)
+    {
+        // Arrange
+        factory.TestClaims = default;
+
+        // Act
+        var result = await establishmentsClient.SearchEstablishments2Async(null, null, null, null, default);
+
+        var establishmentDtos = result.ToList();
+
+        // Assert
+        Assert.NotNull(establishmentDtos);
+        Assert.Equal(3, establishmentDtos.Count);
+    }
+
+    [Theory]
+    [CustomAutoData(typeof(CustomWebApplicationDbContextFactoryCustomization<Startup>))]
+    public async Task SearchEstablishmentsAsync_ShouldReturnAllEstablishments_WhenClosedDateIsFalse(
+    CustomWebApplicationDbContextFactory<Startup> factory,
+    IEstablishmentsV4Client establishmentsClient)
+    {
+        // Arrange
+        factory.TestClaims = default;
+
+        // Act
+        var result = await establishmentsClient.SearchEstablishments2Async(null, null, null, false, default);
+
+        var establishmentDtos = result.ToList();
+
+        // Assert
+        Assert.NotNull(establishmentDtos);
+        Assert.Equal(3, establishmentDtos.Count);
+    }
+
+    [Theory]
+    [CustomAutoData(typeof(CustomWebApplicationDbContextFactoryCustomization<Startup>))]
+    public async Task SearchEstablishmentsAsync_ShouldReturnAllEstablishments_WhenClosedDateIsTrue(
+    CustomWebApplicationDbContextFactory<Startup> factory,
+    IEstablishmentsV4Client establishmentsClient)
+    {
+        // Arrange
+        factory.TestClaims = default;
+
+        // Act
+        var result = await establishmentsClient.SearchEstablishments2Async(null, null, null, true, default);
+
+        var establishmentDtos = result.ToList();
+
+        // Assert
+        Assert.NotNull(establishmentDtos);
+        Assert.Equal(2, establishmentDtos.Count);
+    }
+}

--- a/Dfe.AcademiesApi.Client/Generated/Client.g.cs
+++ b/Dfe.AcademiesApi.Client/Generated/Client.g.cs
@@ -2888,9 +2888,9 @@ namespace Dfe.AcademiesApi.Client
         /// <param name="urn">Unique Reference Numbers (URN).</param>
         /// <returns>Successfully executed the search and returned Establishments.</returns>
         /// <exception cref="AcademiesApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<EstablishmentDto>> SearchEstablishments2Async(string? name, string? ukPrn, string? urn)
+        public virtual System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<EstablishmentDto>> SearchEstablishments2Async(string? name, string? ukPrn, string? urn, bool? excludeClosed)
         {
-            return SearchEstablishments2Async(name, ukPrn, urn, System.Threading.CancellationToken.None);
+            return SearchEstablishments2Async(name, ukPrn, urn, excludeClosed, System.Threading.CancellationToken.None);
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -2902,7 +2902,7 @@ namespace Dfe.AcademiesApi.Client
         /// <param name="urn">Unique Reference Numbers (URN).</param>
         /// <returns>Successfully executed the search and returned Establishments.</returns>
         /// <exception cref="AcademiesApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<EstablishmentDto>> SearchEstablishments2Async(string? name, string? ukPrn, string? urn, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<EstablishmentDto>> SearchEstablishments2Async(string? name, string? ukPrn, string? urn, bool? excludeClosed, System.Threading.CancellationToken cancellationToken)
         {
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -2929,6 +2929,10 @@ namespace Dfe.AcademiesApi.Client
                     if (urn != null)
                     {
                         urlBuilder_.Append(System.Uri.EscapeDataString("urn")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(urn, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    if (excludeClosed != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("excludeClosed")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(excludeClosed, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
                     }
                     urlBuilder_.Length--;
 

--- a/Dfe.AcademiesApi.Client/Generated/Contracts.g.cs
+++ b/Dfe.AcademiesApi.Client/Generated/Contracts.g.cs
@@ -361,7 +361,7 @@ namespace Dfe.AcademiesApi.Client.Contracts
         /// <param name="urn">Unique Reference Numbers (URN).</param>
         /// <returns>Successfully executed the search and returned Establishments.</returns>
         /// <exception cref="AcademiesApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<EstablishmentDto>> SearchEstablishments2Async(string? name, string? ukPrn, string? urn);
+        System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<EstablishmentDto>> SearchEstablishments2Async(string? name, string? ukPrn, string? urn, bool? excludeClosed);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
@@ -372,7 +372,7 @@ namespace Dfe.AcademiesApi.Client.Contracts
         /// <param name="urn">Unique Reference Numbers (URN).</param>
         /// <returns>Successfully executed the search and returned Establishments.</returns>
         /// <exception cref="AcademiesApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<EstablishmentDto>> SearchEstablishments2Async(string? name, string? ukPrn, string? urn, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<EstablishmentDto>> SearchEstablishments2Async(string? name, string? ukPrn, string? urn, bool? excludeClosed, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves a list of establishment Unique Reference Numbers (URNs) by region.

--- a/Dfe.AcademiesApi.Client/Generated/swagger.json
+++ b/Dfe.AcademiesApi.Client/Generated/swagger.json
@@ -852,6 +852,15 @@
               "nullable": true
             },
             "x-position": 3
+          },
+          {
+            "name": "excludeClosed",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "x-position": 4
           }
         ],
         "responses": {

--- a/Tests/Dfe.Academies.Application.Tests/Queries/Establishment/EstablishmentQueriesTests.cs
+++ b/Tests/Dfe.Academies.Application.Tests/Queries/Establishment/EstablishmentQueriesTests.cs
@@ -91,7 +91,8 @@ namespace Dfe.Academies.Application.Tests.Queries.Establishment
             string urn = "1010101";
             string name = "Test name";
             string ukPrn = "Test UkPrn";
-            mockRepo.Setup(x => x.Search(It.Is<string>(v => v == name), It.Is<string>(v => v == ukPrn), It.Is<string>(v => v == urn), It.IsAny<CancellationToken>())).Returns(Task.FromResult(establishments));
+            bool? excludeClosed = null;
+            mockRepo.Setup(x => x.Search(It.Is<string>(v => v == name), It.Is<string>(v => v == ukPrn), It.Is<string>(v => v == urn), It.Is<bool?>(x => x == excludeClosed), It.IsAny<CancellationToken>())).Returns(Task.FromResult(establishments));
 
             var establishmentQueries = new EstablishmentQueries(
                 mockRepo.Object, mockTrustRepo.Object, mockCensusRepo.Object);
@@ -103,11 +104,13 @@ namespace Dfe.Academies.Application.Tests.Queries.Establishment
                 name,
                 ukPrn,
                 urn,
+                excludeClosed,
                 cancellationToken);
 
             // Assert
             result.Should().BeOfType(typeof((List<EstablishmentDto>, int)));
-            foreach (var establishmentDto in result.Item1) {
+            foreach (var establishmentDto in result.Item1)
+            {
                 var establishment = establishments.Single(x => x.URN.ToString() == establishmentDto.Urn);
                 Assert.True(HasMappedCorrectly(establishmentDto, establishment));
             }
@@ -192,7 +195,7 @@ namespace Dfe.Academies.Application.Tests.Queries.Establishment
             // Assert
             result.Should().BeOfType(typeof(List<EstablishmentDto>));
             result.Should().HaveCount(0);
-            
+
         }
 
         [Fact]
@@ -220,11 +223,12 @@ namespace Dfe.Academies.Application.Tests.Queries.Establishment
 
             // Assert
             result.Should().BeOfType(typeof(List<EstablishmentDto>));
-            
-            Assert.All(result, x => {
+
+            Assert.All(result, x =>
+            {
                 var establishment = establishments.Single(es => es.UKPRN == x.Ukprn);
                 Assert.True(HasMappedCorrectly(x, establishment));
-                });
+            });
         }
 
 

--- a/Tests/Dfe.Academies.Tests.Common/Customizations/CustomWebApplicationDbContextFactoryCustomization.cs
+++ b/Tests/Dfe.Academies.Tests.Common/Customizations/CustomWebApplicationDbContextFactoryCustomization.cs
@@ -1,7 +1,9 @@
 ﻿using AutoFixture;
 using Dfe.Academies.Infrastructure;
 using Dfe.Academies.Tests.Common.Seeders;
+using Dfe.AcademiesApi.Client;
 using Dfe.AcademiesApi.Client.Contracts;
+using Dfe.TramsDataApi.Client.Extensions;
 using DfE.CoreLibs.Testing.Mocks.Authentication;
 using DfE.CoreLibs.Testing.Mocks.WebApplicationFactory;
 using Microsoft.AspNetCore.Authentication;
@@ -10,8 +12,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net.Http.Headers;
 using System.Security.Claims;
-using Dfe.AcademiesApi.Client;
-using Dfe.TramsDataApi.Client.Extensions;
 using TramsDataApi.DatabaseModels;
 
 namespace Dfe.Academies.Tests.Common.Customizations
@@ -61,8 +61,9 @@ namespace Dfe.Academies.Tests.Common.Customizations
                 var services = new ServiceCollection();
                 services.AddSingleton<IConfiguration>(config);
                 services.AddAcademiesApiClient<IEstablishmentsV1Client, EstablishmentsV1Client>(config, client);
+                services.AddAcademiesApiClient<IEstablishmentsV4Client, EstablishmentsV4Client>(config, client);
                 services.AddAcademiesApiClient<ITrustsV1Client, TrustsV1Client>(config, client);
-                
+
                 services.AddDbContext<LegacyTramsDbContext>(options =>
                     options.UseSqlServer("DataSource=:memory:"));
                 var serviceProvider = services.BuildServiceProvider();
@@ -71,6 +72,7 @@ namespace Dfe.Academies.Tests.Common.Customizations
                 fixture.Inject(serviceProvider);
                 fixture.Inject(client);
                 fixture.Inject(serviceProvider.GetRequiredService<IEstablishmentsV1Client>());
+                fixture.Inject(serviceProvider.GetRequiredService<IEstablishmentsV4Client>());
                 fixture.Inject(serviceProvider.GetRequiredService<ITrustsV1Client>());
 
                 fixture.Inject(new List<Claim>());

--- a/Tests/Dfe.Academies.Tests.Common/Seeders/MstrContextSeeder.cs
+++ b/Tests/Dfe.Academies.Tests.Common/Seeders/MstrContextSeeder.cs
@@ -52,7 +52,8 @@ namespace Dfe.Academies.Tests.Common.Seeders
                     Email = "schoolA@example.com",
                     Modified = DateTime.UtcNow,
                     ModifiedBy = "System",
-                    ParliamentaryConstituency = "Test Constituency 1"
+                    ParliamentaryConstituency = "Test Constituency 1",
+                    CloseDate = null,
                 };
                 var establishment2 = new Establishment
                 {
@@ -67,9 +68,26 @@ namespace Dfe.Academies.Tests.Common.Seeders
                     Email = "schoolB@example.com",
                     Modified = DateTime.UtcNow,
                     ModifiedBy = "System",
-                    ParliamentaryConstituency = "Test Constituency 2"
+                    ParliamentaryConstituency = "Test Constituency 2",
+                    CloseDate = null,
                 };
-                mstrContext.Establishments.AddRange(establishment1, establishment2);
+                var establishment3 = new Establishment
+                {
+                    SK = 3,
+                    URN = 44,
+                    EstablishmentName = "School C",
+                    LocalAuthorityId = mstrContext.LocalAuthorities.FirstOrDefault()?.SK,
+                    EstablishmentTypeId = mstrContext.EstablishmentTypes.FirstOrDefault()?.SK,
+                    Latitude = 53.3763,
+                    Longitude = -3.1427,
+                    MainPhone = "09876542211",
+                    Email = "schoolC@example.com",
+                    Modified = DateTime.UtcNow,
+                    ModifiedBy = "System",
+                    ParliamentaryConstituency = "Test Constituency 3",
+                    CloseDate = DateTime.UtcNow,
+                };
+                mstrContext.Establishments.AddRange(establishment1, establishment2, establishment3);
 
                 // Populate EducationEstablishmentTrust
                 var educationEstablishmentTrust1 = new EducationEstablishmentTrust

--- a/TramsDataApi/Controllers/V4/EstablishmentsController.cs
+++ b/TramsDataApi/Controllers/V4/EstablishmentsController.cs
@@ -93,14 +93,14 @@ namespace TramsDataApi.Controllers.V4
         [Route("establishments")]
         [SwaggerOperation(Summary = "Search Establishments", Description = "Returns a list of Establishments based on search criteria.")]
         [SwaggerResponse(200, "Successfully executed the search and returned Establishments.", typeof(List<EstablishmentDto>))]
-        public async Task<ActionResult<List<EstablishmentDto>>> SearchEstablishments(string name, string ukPrn, string urn, CancellationToken cancellationToken)
+        public async Task<ActionResult<List<EstablishmentDto>>> SearchEstablishments(string name, string ukPrn, string urn, bool? excludeClosed, CancellationToken cancellationToken)
         {
             _logger.LogInformation(
                 "Searching for establishments by name \"{name}\", UKPRN \"{ukPrn}\", urn \"{number}\"",
                 name, ukPrn, urn);
 
             var (establishments, recordCount) = await _establishmentQueries
-                .Search(name, ukPrn, urn, cancellationToken).ConfigureAwait(false);
+                .Search(name, ukPrn, urn, excludeClosed, cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation(
                 "Found {count} establishments for name \"{name}\", UKPRN \"{ukPrn}\", urn \"{number}\"",
@@ -123,14 +123,14 @@ namespace TramsDataApi.Controllers.V4
         [SwaggerOperation(Summary = "Get Establishment Unique Reference Numbers (URNs) by Region", Description = "Returns a list of establishment Unique Reference Numbers (URNs) by specified regions.")]
         [SwaggerResponse(200, "Successfully found and returned the establishment Unique Reference Numbers (URNs).", typeof(IEnumerable<int>))]
         [SwaggerResponse(404, "No establishments found for specified regions.")]
-        public async Task<ActionResult<IEnumerable<int>>> GetURNsByRegion([FromQuery] string[] regions,  CancellationToken cancellationToken)
+        public async Task<ActionResult<IEnumerable<int>>> GetURNsByRegion([FromQuery] string[] regions, CancellationToken cancellationToken)
         {
-			_logger.LogInformation(
-				"Searching for establishment URNs by regions\"{regions}\"",
+            _logger.LogInformation(
+                "Searching for establishment URNs by regions\"{regions}\"",
                 regions);
 
             var establishmentURNs = await _establishmentQueries
-                .GetURNsByRegion(regions, cancellationToken).ConfigureAwait(false);          
+                .GetURNsByRegion(regions, cancellationToken).ConfigureAwait(false);
 
             _logger.LogDebug(JsonSerializer.Serialize(establishmentURNs));
 
@@ -154,7 +154,7 @@ namespace TramsDataApi.Controllers.V4
             var commaSeparatedRequestUrns = string.Join(",", request);
             _logger.LogInformation($"Attemping to get establishments by Unique Reference Numbers (URNs): {commaSeparatedRequestUrns}");
 
-            var establishments = await _establishmentQueries.GetByUrns(request, cancellationToken).ConfigureAwait(false);         
+            var establishments = await _establishmentQueries.GetByUrns(request, cancellationToken).ConfigureAwait(false);
 
             if (establishments == null)
             {


### PR DESCRIPTION
- added optional parameter to the v4 establishments search, this is a non breaking change and should not affect any consumers of the endpoint. It has been added because the autocomplete in various services is showing closed schools/academies and is resulting in users adding the wrong schools to the system.