### PR TITLE
Wait for quality gate response from Sonar before finishing the workflow

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -79,7 +79,7 @@ jobs:
         ConnectionStrings__DefaultConnection: ${{ env.CONNECTION_STRING }}
         CI: true
       run: |
-        dotnet-sonarscanner begin /d:sonar.scanner.skipJreProvisioning=true /k:"DFE-Digital_academies-api" /o:"dfe-digital" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.coverageReportPaths=CoverageReport/SonarQube.xml
+        dotnet-sonarscanner begin /d:sonar.qualitygate.wait=true /d:sonar.scanner.skipJreProvisioning=true /k:"DFE-Digital_academies-api" /o:"dfe-digital" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.coverageReportPaths=CoverageReport/SonarQube.xml
         dotnet build --no-restore
         dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage"
         reportgenerator -reports:./**/coverage.cobertura.xml -targetdir:./CoverageReport -reporttypes:SonarQube


### PR DESCRIPTION
This forms part of the work to make Sonarqube a mandatory quality gate.
Introducing the `sonar.qualitygate.wait=true` parameter ensures that the scanner will wait for the report to be generated and will fail the workflow if the gate is red, rather than completing the workflow regardless of the gate